### PR TITLE
ユーザー一覧にページネーションを追加

### DIFF
--- a/plugins/baser-core/src/Controller/Admin/UsersController.php
+++ b/plugins/baser-core/src/Controller/Admin/UsersController.php
@@ -84,6 +84,8 @@ class UsersController extends BcAdminAppController
 		$this->setViewConditions('User', ['default' => $default]);
         $this->paginate = [
             'contain' => ['UserGroups'],
+            'order' => ['Users.id'],
+            'limit' => $this->request->getParam('pass')['num'],
         ];
         $users = $this->paginate(
             $this->Users->find('all')

--- a/plugins/baser-core/tests/Fixture/Controller/UsersController/UsersPaginationFixture.php
+++ b/plugins/baser-core/tests/Fixture/Controller/UsersController/UsersPaginationFixture.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <https://basercms.net>
+ * Copyright (c) baserCMS User Community <https://basercms.net/community/>
+ *
+ * @copyright     Copyright (c) baserCMS User Community
+ * @link          https://basercms.net baserCMS Project
+ * @since         5.0.0
+ * @license       http://basercms.net/license/index.html MIT License
+ */
+
+namespace BaserCore\Test\Fixture\Controller\UsersController;
+
+use Cake\TestSuite\Fixture\TestFixture;
+use Cake\ORM\TableRegistry;
+
+/**
+ * Class UsersPaginationFixture
+ * @package BaserCore\Test\Fixture
+ */
+class UsersPaginationFixture extends TestFixture
+{
+    public $import = ['table' => 'users'];
+
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination1',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination1',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination2',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination2',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination3',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination3',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination4',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination4',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination5',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination5',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination6',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination6',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination7',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination7',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination8',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination8',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination9',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination9',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination10',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination10',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination11',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination11',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination12',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination12',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination13',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination13',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination14',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination14',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination15',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination15',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination16',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination16',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination17',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination17',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            // 'id' => 8,
+            'name' => 'Lorem ipsum dolor sit amet Pagination18',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination18',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination19',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination19',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination20',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination20',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+        [
+            'name' => 'Lorem ipsum dolor sit amet Pagination21',
+            'password' => 'Lorem ipsum dolor sit amet',
+            'real_name_1' => 'Lorem ipsum dolor sit amet',
+            'real_name_2' => 'Lorem ipsum dolor sit amet',
+            'email' => 'Lorem ipsum dolor sit amet Pagination21',
+            'nickname' => 'Lorem ipsum dolor sit amet',
+            'created' => '2017-05-03 10:57:07',
+            'modified' => '2017-05-03 10:57:07'
+        ],
+    ];
+}

--- a/plugins/baser-core/tests/TestCase/Controller/UsersControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/UsersControllerTest.php
@@ -30,7 +30,10 @@ class UsersControllerTest extends TestCase
         'plugin.BaserCore.Users',
         'plugin.BaserCore.UsersUserGroups',
         'plugin.BaserCore.UserGroups',
+        'plugin.BaserCore.Controller/UsersController/UsersPagination',
     ];
+
+    public $autoFixtures = false;
 
     /**
      * set up
@@ -38,6 +41,14 @@ class UsersControllerTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        $this->loadFixtures('UsersUserGroups', 'UserGroups');
+        if ($this->getName() == 'testIndex_pagination') {
+            $this->loadFixtures('Controller\UsersController\UsersPagination');
+        } else {
+            $this->loadFixtures('Users');
+        }
+
         $config = $this->getTableLocator()->exists('Users') ? [] : ['className' => 'BaserCore\Model\Table\UsersTable'];
         $Users = $this->getTableLocator()->get('Users', $config);
         $this->session(['AuthAdmin' => $Users->get(1)]);
@@ -51,6 +62,17 @@ class UsersControllerTest extends TestCase
     public function testIndex()
     {
         $this->get('/baser/admin/users/');
+        $this->assertResponseOk();
+    }
+
+    /**
+     * Test index pagination
+     *
+     * @return void
+     */
+    public function testIndex_pagination()
+    {
+        $this->get('/baser/admin/users/?page=2');
         $this->assertResponseOk();
     }
 

--- a/plugins/bc-admin-third/templates/Element/Admin/pagination.php
+++ b/plugins/bc-admin-third/templates/Element/Admin/pagination.php
@@ -15,3 +15,40 @@ use BaserCore\View\AppView;
  * pagination
  * @var AppView $this
  */
+if (!isset($modules)) {
+    $modules = 8;
+}
+if (!isset($options)) {
+    $options = [];
+}
+$pageCount = 0;
+if (!empty($this->Paginator->counter('{{pages}}'))) {
+    $pageCount = $this->Paginator->counter('{{pages}}');
+}
+$this->Paginator->setTemplates([
+    'prevActive'   => '<span class="prev"><a href="{{url}}" rel="prev">{{text}}</a></span>',
+    'prevDisabled' => '<span class="prev disabled">{{text}}</span>',
+    'nextActive'   => '<span class="next"><a href="{{url}}" rel="next">{{text}}</a></span>',
+    'nextDisabled' => '<span class="next disabled">{{text}}</span>',
+    'current'      => '<span class="current number">{{text}}</span>',
+    'number'       => '<span class="number"><a href="{{url}}">{{text}}</a></span>'
+]);
+ ?>
+
+
+<div class="pagination bca-pagination">
+    <?php if ($pageCount > 1): ?>
+        <div class="page-numbers bca-page-numbers">
+            <?php echo $this->Paginator->prev(' < ', array_merge(['class' => 'prev'], $options)) ?>
+            <?php // ToDo : 我流 アイコンのリンクがHTMLで指定できるように
+            //echo $this->Paginator->prev('<span class="bca-icon--allow-left"><span class="bca-icon-label">前へ</span></span>', array_merge(['class' => 'prev', 'escape' => false], $options)) ?>
+            <?php echo $this->Html->tag('span', $this->Paginator->numbers(array_merge(['separator' => '', 'class' => 'number', 'modulus' => $modules], $options), ['class' => 'page-numbers'])) ?>
+            <?php echo $this->Paginator->next(' > ', array_merge(['class' => 'next'], $options)) ?>
+            <?php // ToDo : 我流 アイコンのリンクがHTMLで指定できるように
+            //echo $this->Paginator->next('<span class="bca-icon--allow-right"><span class="bca-icon-label">次へ</span></span>', array_merge(['class' => 'next', 'escape' => false], $options)) ?>
+        </div>
+    <?php endif ?>
+    <div class="page-result bca-page-result">
+        <?php echo $this->Paginator->counter(sprintf(__d('baser', '%s～%s 件'), '<span class="page-start-num">{{start}}</span>', '<span class="page-end-num">{{end}}</span>') . ' ／ ' . sprintf(__d('baser', '%s 件'), '<span class="page-total-num">{{count}}</span>')) ?>
+    </div>
+</div>


### PR DESCRIPTION
下記の処理を追加しました。

1. 管理画面ユーザー一覧にページネーションを追加
1. BcAdminThird にページネーションパーツを追加
1. テストに UsersController のページネーションのテストを追加
1. フィクスチャに users のページネーション用のデータを追加

2 のページネーションでは CakePHP4 と CakePHP2 で出力される HTML が異なる為、 `Paginator::setTemplates()` で CakePHP2 の HTML を設定しています。 `/config/` 配下で設定する方がスマートですがテーマから分離される為、Element 内で記述しています。
3 のテストは `autoFixtures` を無効にし、`setUp` 内でロードするフィクスチャを切り替えるようにしました。

ご確認よろしくお願いいたします！