### PR TITLE
ユーザーグループ一覧にページネーションを追加

### DIFF
--- a/plugins/baser-core/src/Controller/Admin/UserGroupsController.php
+++ b/plugins/baser-core/src/Controller/Admin/UserGroupsController.php
@@ -81,6 +81,10 @@ class UserGroupsController extends BcAdminAppController
         $this->request = $this->request->withParam('pass', ['num' => $this->siteConfigs['admin_list_num']]);
         $default = ['named' => ['num' => $this->siteConfigs['admin_list_num']]];
         $this->setViewConditions('UserGroup', ['default' => $default]);
+        $this->paginate = [
+            'order' => ['UserGroups.id'],
+            'limit' => $this->request->getParam('pass')['num'],
+        ];
         $userGroups = $this->paginate(
             $this->UserGroups->find('all')
                 ->limit($this->request->getParam('pass')['num'])

--- a/plugins/baser-core/tests/Fixture/Controller/UserGroupsController/UserGroupsPaginationFixture.php
+++ b/plugins/baser-core/tests/Fixture/Controller/UserGroupsController/UserGroupsPaginationFixture.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <https://basercms.net>
+ * Copyright (c) baserCMS User Community <https://basercms.net/community/>
+ *
+ * @copyright     Copyright (c) baserCMS User Community
+ * @link          https://basercms.net baserCMS Project
+ * @since         5.0.0
+ * @license       http://basercms.net/license/index.html MIT License
+ */
+
+namespace BaserCore\Test\Fixture\Controller\UserGroupsController;
+
+use Cake\TestSuite\Fixture\TestFixture;
+use Cake\ORM\TableRegistry;
+
+/**
+ * Class UserGroupsPaginationFixture
+ * @package BaserCore\Test\Fixture
+ */
+class UserGroupsPaginationFixture extends TestFixture
+{
+    public $import = ['table' => 'user_groups'];
+
+    /**
+     * Initialize the fixture.
+     *
+     * @return void
+     */
+    public function init(): void
+    {
+        $this->records = [];
+
+        for ($i = 1; $i <= 21; $i++) {
+            $this->records[] = [
+                'name' => 'pagination'.$i,
+                'title' => 'ページネーション'.$i,
+                'auth_prefix' => 'admin',
+                'use_admin_globalmenu' => false,
+                'default_favorites' => 'YTo3OntpOjA7YToyOntzOjQ6Im5hbWUiO3M6MjE6IuOCs+ODs+ODhuODs+ODhOeuoeeQhiI7czozOiJ1cmwiO3M6MjE6Ii9hZG1pbi9jb250ZW50cy9pbmRleCI7fWk6MTthOjI6e3M6NDoibmFtZSI7czoxODoi5paw552A5oOF5aCx566h55CGIjtzOjM6InVybCI7czozMDoiL2FkbWluL2Jsb2cvYmxvZ19wb3N0cy9pbmRleC8xIjt9aToyO2E6Mjp7czo0OiJuYW1lIjtzOjMwOiLmlrDnnYDmg4XloLHjgrPjg6Hjg7Pjg4jkuIDopqciO3M6MzoidXJsIjtzOjMzOiIvYWRtaW4vYmxvZy9ibG9nX2NvbW1lbnRzL2luZGV4LzEiO31pOjM7YToyOntzOjQ6Im5hbWUiO3M6MjQ6IuOBiuWVj+OBhOWQiOOCj+OBm+ioreWumiI7czozOiJ1cmwiO3M6MzE6Ii9hZG1pbi9tYWlsL21haWxfZmllbGRzL2luZGV4LzEiO31pOjQ7YToyOntzOjQ6Im5hbWUiO3M6MjQ6IuOBiuWVj+OBhOWQiOOCj+OBm+S4gOimpyI7czozOiJ1cmwiO3M6MzM6Ii9hZG1pbi9tYWlsL21haWxfbWVzc2FnZXMvaW5kZXgvMSI7fWk6NTthOjI6e3M6NDoibmFtZSI7czoyNDoi44Ki44OD44OX44Ot44O844OJ566h55CGIjtzOjM6InVybCI7czozMToiL2FkbWluL3VwbG9hZGVyL3VwbG9hZGVyX2ZpbGVzLyI7fWk6NjthOjI6e3M6NDoibmFtZSI7czoxNToi44Kv44Os44K444OD44OIIjtzOjM6InVybCI7czoyMDoiamF2YXNjcmlwdDpjcmVkaXQoKTsiO319',
+                'use_move_contents' => false,
+                'created' => date('Y-m-d H:i:s'),
+                'modified' => date('Y-m-d H:i:s')
+            ];
+        }
+
+        parent::init();
+    }
+}

--- a/plugins/baser-core/tests/TestCase/Controller/UserGroupsControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/UserGroupsControllerTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <https://basercms.net>
+ * Copyright (c) baserCMS User Community <https://basercms.net/community/>
+ *
+ * @copyright     Copyright (c) baserCMS User Community
+ * @link          https://basercms.net baserCMS Project
+ * @since         5.0.0
+ * @license       http://basercms.net/license/index.html MIT License
+ */
+
+namespace BaserCore\Test\TestCase\Controller;
+
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * BaserCore\Controller\UserGroupsController Test Case
+ */
+class UserGroupsControllerTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'plugin.BaserCore.Users',
+        'plugin.BaserCore.UsersUserGroups',
+        'plugin.BaserCore.UserGroups',
+        'plugin.BaserCore.Controller/UserGroupsController/UserGroupsPagination',
+    ];
+
+    public $autoFixtures = false;
+
+    /**
+     * set up
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadFixtures('UsersUserGroups', 'Users');
+        if ($this->getName() == 'testIndex_pagination') {
+            $this->loadFixtures('Controller\UserGroupsController\UserGroupsPagination');
+        } else {
+            $this->loadFixtures('UserGroups');
+        }
+
+        $config = $this->getTableLocator()->exists('UserGroups') ? [] : ['className' => 'BaserCore\Model\Table\UserGroupsTable'];
+        $UserGroups = $this->getTableLocator()->get('UserGroups', $config);
+        $this->session(['AuthAdmin' => $UserGroups->get(1)]);
+    }
+
+    /**
+     * Test index method
+     *
+     * @return void
+     */
+    public function testIndex()
+    {
+        $this->get('/baser/admin/user_groups/');
+        $this->assertResponseOk();
+    }
+
+    /**
+     * Test index pagination
+     *
+     * @return void
+     */
+    public function testIndex_pagination()
+    {
+        $this->get('/baser/admin/user_groups/?page=2');
+        $this->assertResponseOk();
+    }
+
+    /**
+     * Test add method
+     *
+     * @return void
+     */
+    public function testAdd()
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test edit method
+     *
+     * @return void
+     */
+    public function testEdit()
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test delete method
+     *
+     * @return void
+     */
+    public function testDelete()
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+}


### PR DESCRIPTION
下記の処理を追加しました。

1. 管理画面ユーザーグループ一覧にページネーションを追加
1. テストに UserGroupsController のページネーションのテストを追加
1. フィクスチャに user_groups のページネーション用のデータを追加

2 のテストは元々 UserGroupsController のテストそのものがなかったので一覧表示とページネーションのテストのみ追加しております。

ご確認よろしくお願いいたします！