### PR TITLE
ユーザー一覧に表示件数切替を追加

### DIFF
--- a/plugins/baser-core/src/Controller/Admin/UsersController.php
+++ b/plugins/baser-core/src/Controller/Admin/UsersController.php
@@ -78,11 +78,13 @@ class UsersController extends BcAdminAppController
 	 */
     public function index(): void
     {
-        $this->setViewConditions('', ['default' => ['named' => ['num' => $this->siteConfigs['admin_list_num']]]]);
-        $query = $this->Users->find()
-            ->order(['Users.id'])
-            ->limit($this->request->getParam('pass')['num'])
-            ->contain('UserGroups');
+        $this->setViewConditions('User', ['default' => ['query' => ['num' => $this->siteConfigs['admin_list_num']]]]);
+        $this->paginate = [
+            'order' => ['Users.id'],
+            'limit' => $this->request->getQuery('num'),
+            'contain' => ['UserGroups']
+        ];
+        $query = $this->Users->find('all', $this->paginate);
         $query = $this->Users->createWhere($query, $this->request);
         $this->set([
             'users' => $this->paginate($query)

--- a/plugins/baser-core/tests/Fixture/Controller/UsersController/UsersPaginationFixture.php
+++ b/plugins/baser-core/tests/Fixture/Controller/UsersController/UsersPaginationFixture.php
@@ -23,221 +23,27 @@ class UsersPaginationFixture extends TestFixture
     public $import = ['table' => 'users'];
 
     /**
-     * Records
+     * Initialize the fixture.
      *
-     * @var array
+     * @return void
      */
-    public $records = [
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination1',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination1',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination2',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination2',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination3',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination3',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination4',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination4',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination5',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination5',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination6',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination6',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination7',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination7',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination8',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination8',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination9',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination9',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination10',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination10',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination11',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination11',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination12',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination12',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination13',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination13',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination14',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination14',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination15',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination15',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination16',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination16',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination17',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination17',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            // 'id' => 8,
-            'name' => 'Lorem ipsum dolor sit amet Pagination18',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination18',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination19',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination19',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination20',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination20',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-        [
-            'name' => 'Lorem ipsum dolor sit amet Pagination21',
-            'password' => 'Lorem ipsum dolor sit amet',
-            'real_name_1' => 'Lorem ipsum dolor sit amet',
-            'real_name_2' => 'Lorem ipsum dolor sit amet',
-            'email' => 'Lorem ipsum dolor sit amet Pagination21',
-            'nickname' => 'Lorem ipsum dolor sit amet',
-            'created' => '2017-05-03 10:57:07',
-            'modified' => '2017-05-03 10:57:07'
-        ],
-    ];
+    public function init(): void
+    {
+        $this->records = [];
+
+        for ($i = 1; $i <= 21; $i++) {
+            $this->records[] = [
+                'name' => 'Lorem ipsum dolor sit amet Pagination'.$i,
+                'password' => 'Lorem ipsum dolor sit amet',
+                'real_name_1' => 'Lorem ipsum dolor sit amet',
+                'real_name_2' => 'Lorem ipsum dolor sit amet',
+                'email' => 'Lorem ipsum dolor sit amet Pagination',
+                'nickname' => 'Lorem ipsum dolor sit amet',
+                'created' => date('Y-m-d H:i:s'),
+                'modified' => date('Y-m-d H:i:s')
+            ];
+        }
+
+        parent::init();
+    }
 }

--- a/plugins/baser-core/tests/TestCase/Controller/UsersControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/UsersControllerTest.php
@@ -72,7 +72,7 @@ class UsersControllerTest extends TestCase
      */
     public function testIndex_pagination()
     {
-        $this->get('/baser/admin/users/?page=2');
+        $this->get('/baser/admin/users/?num=1&page=21');
         $this->assertResponseOk();
     }
 

--- a/plugins/bc-admin-third/templates/element/Admin/list_num.php
+++ b/plugins/bc-admin-third/templates/element/Admin/list_num.php
@@ -15,3 +15,33 @@ use BaserCore\View\AppView;
  * list num
  * @var AppView $this
  */
+$currentNum = '';
+if (empty($nums)) {
+	$nums = ['10', '30', '50', '100'];
+}
+if (!is_array($nums)) {
+	$nums = [$nums];
+}
+if (!empty($this->request->getQuery('num'))) {
+	$currentNum = $this->request->getQuery('num');
+}
+$links = [];
+foreach ($nums as $num) {
+	if ($currentNum != $num) {
+		$links[] = '<span>' . $this->BcBaser->getLink($num, ['?' => array_merge($this->request->getQuery(), ['num' => $num, 'page' => null])]) . '</span>';
+	} else {
+		$links[] = '<span class="current">' . $num . '</span>';
+	}
+}
+if ($links) {
+	$link = implode('｜', $links);
+}
+?>
+
+
+<?php if ($link): ?>
+	<dl class="list-num bca-list-num">
+		<dt class="bca-list-num__title"><?php echo __d('baser', '表示件数')?></dt>
+        <dd class="bca-list-num__data"><?php echo $link ?></dd>
+	</dl>
+<?php endif ?>


### PR DESCRIPTION
下記の処理を追加しました。

1. 管理画面ユーザー一覧に表示件数切替を追加
1. BcAdminThird に表示件数切替パーツを追加
1. テストの UsersController のページネーションのテストに表示件数のパラメータを追加
1. フィクスチャの users のページネーション用のデータをリファクタリング

1 の表示件数切替では CakePHP4 で名前付きパラメータの取得が廃止された為、GET で実装しています。
3 のテストはページネーションと表示件数は複合条件になり単体でテストできないと思い、既存のページネーションテストにパラーメータを追加しました。

ご確認よろしくお願いいたします！