### PR TITLE
ユーザーグループ一覧に表示件数切替を追加

### DIFF
--- a/plugins/baser-core/src/Controller/Admin/UserGroupsController.php
+++ b/plugins/baser-core/src/Controller/Admin/UserGroupsController.php
@@ -78,19 +78,14 @@ class UserGroupsController extends BcAdminAppController
      */
     public function index()
     {
-        $this->request = $this->request->withParam('pass', ['num' => $this->siteConfigs['admin_list_num']]);
-        $default = ['named' => ['num' => $this->siteConfigs['admin_list_num']]];
-        $this->setViewConditions('UserGroup', ['default' => $default]);
+        $this->setViewConditions('UserGroup', ['default' => ['query' => ['num' => $this->siteConfigs['admin_list_num']]]]);
         $this->paginate = [
             'order' => ['UserGroups.id'],
-            'limit' => $this->request->getParam('pass')['num'],
+            'limit' => $this->request->getQuery('num'),
         ];
-        $userGroups = $this->paginate(
-            $this->UserGroups->find('all')
-                ->limit($this->request->getParam('pass')['num'])
-        );
+        $query = $this->UserGroups->find('all', $this->paginate);
         $this->set([
-            'userGroups' => $userGroups,
+            'userGroups' => $this->paginate($query),
             '_serialize' => ['userGroups']
         ]);
 

--- a/plugins/baser-core/tests/TestCase/Controller/UserGroupsControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/UserGroupsControllerTest.php
@@ -72,7 +72,7 @@ class UserGroupsControllerTest extends TestCase
      */
     public function testIndex_pagination()
     {
-        $this->get('/baser/admin/user_groups/?page=2');
+        $this->get('/baser/admin/user_groups/?num=1&page=21');
         $this->assertResponseOk();
     }
 


### PR DESCRIPTION
下記の処理を追加しました。

1. 管理画面ユーザーグループ一覧に表示件数切替を追加
1. テストの UsersController のページネーションのテストに表示件数のパラメータを追加

2 のテストはページネーションと表示件数は複合条件になり単体でテストできないと思い、既存のページネーションテストにパラメータを追加しました。

ご確認よろしくお願いいたします！