### PR TITLE
ユーザーグループのコピーを実装

### DIFF
--- a/plugins/baser-core/src/Controller/Admin/UserGroupsController.php
+++ b/plugins/baser-core/src/Controller/Admin/UserGroupsController.php
@@ -215,7 +215,7 @@ class UserGroupsController extends BcAdminAppController
      * @param string|null $id User Group id.
      * @return Response|null|void Redirects to index.
      * @throws RecordNotFoundException When record not found.
-     * @throws CopyUserGroupsFailedException When copy failed.
+     * @throws CopyFailedException When copy failed.
      */
     public function copy($id = null)
     {

--- a/plugins/baser-core/src/Controller/Admin/UserGroupsController.php
+++ b/plugins/baser-core/src/Controller/Admin/UserGroupsController.php
@@ -206,4 +206,39 @@ class UserGroupsController extends BcAdminAppController
         }
         return $this->redirect(['action' => 'index']);
     }
+
+    /**
+     * ユーザーグループコピー
+     *
+     * ユーザーグループをコピーする
+     *
+     * @param string|null $id User Group id.
+     * @return Response|null|void Redirects to index.
+     * @throws RecordNotFoundException When record not found.
+     * @throws CopyUserGroupsFailedException When copy failed.
+     */
+    public function copy($id = null)
+    {
+        $this->request->allowMethod(['post']);
+        if (!$id || !is_numeric($id)) {
+            $this->BcMessage->setError(__d('baser', '無効な処理です。'));
+            return $this->redirect(['action' => 'index']);
+        }
+        $userGroup = $this->UserGroups->get($id);
+        try {
+            if ($this->UserGroups->copy($id)) {
+                $this->BcMessage->setSuccess(__d('baser', 'ユーザーグループ「{0}」をコピーしました。', $userGroup->name));
+            } else {
+                $this->BcMessage->setError(__d('baser', 'データベース処理中にエラーが発生しました。'));
+            }
+        } catch (\Exception $e) {
+            $message = [$e->getMessage()];
+            $errors = $e->getErrors();
+            if (!empty($errors)) {
+                foreach ($errors as $error) $message[] = __d('baser', current($error));
+            }
+            $this->BcMessage->setError(implode("\n", $message), false);
+        }
+        return $this->redirect(['action' => 'index']);
+    }
 }

--- a/plugins/baser-core/src/Model/Table/Exception/CopyFailedException.php
+++ b/plugins/baser-core/src/Model/Table/Exception/CopyFailedException.php
@@ -13,11 +13,11 @@ namespace BaserCore\Model\Table\Exception;
 use Cake\Core\Exception\Exception;
 
 /**
- * Class CopyUserGroupsException
+ * Class CopyFailedException
  * @package BaserCore\Model\Table\Execption
  * @property array $errors
  */
-class CopyUserGroupsFailedException extends Exception
+class CopyFailedException extends Exception
 {
     /**
      * validation errors

--- a/plugins/baser-core/src/Model/Table/Exception/CopyUserGroupsFailedException.php
+++ b/plugins/baser-core/src/Model/Table/Exception/CopyUserGroupsFailedException.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <https://basercms.net>
+ * Copyright (c) baserCMS User Community <https://basercms.net/community/>
+ *
+ * @copyright     Copyright (c) baserCMS User Community
+ * @link          https://basercms.net baserCMS Project
+ * @since         5.0.0
+ * @license       http://basercms.net/license/index.html MIT License
+ */
+
+namespace BaserCore\Model\Table\Exception;
+use Cake\Core\Exception\Exception;
+
+/**
+ * Class CopyUserGroupsException
+ * @package BaserCore\Model\Table\Execption
+ * @property array $errors
+ */
+class CopyUserGroupsFailedException extends Exception
+{
+    /**
+     * validation errors
+     *
+     * @var array
+     */
+    public $errors;
+
+    /**
+     * setErrors
+     *
+     * @param array $errors validation errors
+     * @return void
+     */
+    public function setErrors(?array $errors = null)
+    {
+        $this->errors = $errors;
+    }
+
+    /**
+     * getErrors
+     *
+     * @return void
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+}

--- a/plugins/baser-core/src/Model/Table/UserGroupsTable.php
+++ b/plugins/baser-core/src/Model/Table/UserGroupsTable.php
@@ -16,6 +16,7 @@ use Cake\ORM\Behavior\TimestampBehavior as TimestampBehaviorAlias;
 use Cake\Datasource\{EntityInterface, ResultSetInterface as ResultSetInterfaceAlias};
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
+use BaserCore\Model\Table\Exception\CopyUserGroupsFailedException;
 
 /**
  * Class UserGroupsTable
@@ -116,4 +117,48 @@ class UserGroupsTable extends Table
         return $validator;
     }
 
+    /**
+     * ユーザーグループデータをコピーする
+     *
+     * @param int $id ユーザーグループID
+     * @param array $data DBに挿入するデータ
+     * @param bool $recursive 関連したPermissionもcopyするかしないか
+     * @return mixed UserGroups Or false
+     * @throws CopyUserGroupsFailedException When copy failed.
+     */
+    public function copy($id = null, $data = [], $recursive = true) {
+        if ($id && is_numeric($id)) {
+            $data = $this->get($id)->toArray();
+        } else {
+            if (!empty($data['id'])) {
+                $id = $data['id'];
+            }
+        }
+        $data['name'] .= '_copy';
+        $data['title'] .= '_copy';
+
+        unset($data['id']);
+        unset($data['created']);
+        unset($data['modified']);
+
+        $entity = $this->newEntity($data);
+        $errors = $entity->getErrors();
+        if ($errors) {
+            $exception = new CopyUserGroupsFailedException(__d('baser', '処理に失敗しました。'));
+            $exception->setErrors($errors);
+            throw $exception;
+        }
+
+        $result = $this->save($entity);
+        if ($result) {
+            // TODO: Permissionのコピー
+            return $result;
+        } else {
+            if (!isset($errors['name'])) {
+                return $this->copy(null, $data, $recursive);
+            } else {
+                return false;
+            }
+        }
+    }
 }

--- a/plugins/baser-core/src/Model/Table/UserGroupsTable.php
+++ b/plugins/baser-core/src/Model/Table/UserGroupsTable.php
@@ -16,7 +16,7 @@ use Cake\ORM\Behavior\TimestampBehavior as TimestampBehaviorAlias;
 use Cake\Datasource\{EntityInterface, ResultSetInterface as ResultSetInterfaceAlias};
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
-use BaserCore\Model\Table\Exception\CopyUserGroupsFailedException;
+use BaserCore\Model\Table\Exception\CopyFailedException;
 
 /**
  * Class UserGroupsTable
@@ -124,7 +124,7 @@ class UserGroupsTable extends Table
      * @param array $data DBに挿入するデータ
      * @param bool $recursive 関連したPermissionもcopyするかしないか
      * @return mixed UserGroups Or false
-     * @throws CopyUserGroupsFailedException When copy failed.
+     * @throws CopyFailedException When copy failed.
      */
     public function copy($id = null, $data = [], $recursive = true) {
         if ($id && is_numeric($id)) {
@@ -144,7 +144,7 @@ class UserGroupsTable extends Table
         $entity = $this->newEntity($data);
         $errors = $entity->getErrors();
         if ($errors) {
-            $exception = new CopyUserGroupsFailedException(__d('baser', '処理に失敗しました。'));
+            $exception = new CopyFailedException(__d('baser', '処理に失敗しました。'));
             $exception->setErrors($errors);
             throw $exception;
         }

--- a/plugins/baser-core/tests/TestCase/Controller/UserGroupsControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/UserGroupsControllerTest.php
@@ -105,4 +105,19 @@ class UserGroupsControllerTest extends TestCase
     {
         $this->markTestIncomplete('Not implemented yet.');
     }
+
+    /**
+     * Test copy method
+     *
+     * @return void
+     */
+    public function testCopy()
+    {
+        $this->post('/baser/admin/user_groups/copy/1');
+        $this->assertResponseSuccess();
+        $userGroups = $this->getTableLocator()->get('UserGroups');
+        $originalUserGroup = $userGroups->get(1);
+        $query = $userGroups->find()->where(['name' => $originalUserGroup->name.'_copy']);
+        $this->assertEquals(1, $query->count());
+    }
 }

--- a/plugins/baser-core/tests/TestCase/Model/Table/UserGroupsTableTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/UserGroupsTableTest.php
@@ -29,6 +29,15 @@ class UserGroupsTableTest extends BcTestCase {
     public $UserGroups;
 
     /**
+     * Fixtures
+     *
+     * @var array
+     */
+    protected $fixtures = [
+        'plugin.BaserCore.UserGroups',
+    ];
+
+    /**
      * Set Up
      *
      * @return void
@@ -76,6 +85,19 @@ class UserGroupsTableTest extends BcTestCase {
             $fields[] = $key;
         }
         $this->assertEquals(['id', 'name', 'title', 'auth_prefix', 'use_admin_globalmenu', 'default_favorites', 'use_move_contents'], $fields);
+    }
+
+    /**
+     * Test copy
+     *
+     * @return void
+     */
+    public function testCopy()
+    {
+        $this->UserGroups->copy(1);
+        $originalUserGroup = $this->UserGroups->get(1);
+        $query = $this->UserGroups->find()->where(['name' => $originalUserGroup->name.'_copy']);
+        $this->assertEquals(1, $query->count());
     }
 
 }

--- a/plugins/bc-admin-third/templates/element/Admin/UserGroups/index_row.php
+++ b/plugins/bc-admin-third/templates/element/Admin/UserGroups/index_row.php
@@ -37,7 +37,14 @@ use BaserCore\View\AppView;
             <?php $this->BcBaser->link('', ['controller' => 'permissions', 'action' => 'index', $userGroup->id], ['title' => __d('baser', '制限'), 'class' => 'bca-btn-icon', 'data-bca-btn-type' => 'permission', 'data-bca-btn-size' => 'lg']) ?>
         <?php endif ?>
         <?php $this->BcBaser->link('', ['action' => 'edit', $userGroup->id], ['title' => __d('baser', '編集'), 'class' => 'bca-btn-icon', 'data-bca-btn-type' => 'edit', 'data-bca-btn-size' => 'lg']) ?>
-        <?php //$this->BcBaser->link('', ['action' => 'ajax_copy', $userGroup->id], ['title' => __d('baser', 'コピー'), 'class' => 'btn-copy bca-btn-icon', 'data-bca-btn-type' => 'copy', 'data-bca-btn-size' => 'lg']) ?>
+        <?php echo $this->BcForm->postLink(
+            '',
+            ['action' => 'copy', $userGroup->id],
+            ['title' => __d('baser', 'コピー'),
+            'class' => 'btn-copy bca-btn-icon',
+            'data-bca-btn-type' => 'copy',
+            'data-bca-btn-size' => 'lg']
+        ) ?>
         <?php if ($userGroup->name != 'admins'): ?>
             <?= $this->BcForm->postLink(
                 '',


### PR DESCRIPTION
下記の処理を追加しました。

1. 管理画面ユーザーグループのコピーを実装
1. ユーザーグループのコピー失敗時の Exception を追加
1. BcAdminThird のユーザーグループ一覧にコピーアイコンを追加
1. テストに UserGroupsController のユーザーグループコピーのテストを追加
1. テストに UserGroupsTable のユーザーグループコピーのテストを追加

ご確認よろしくお願いいたします！