### PR TITLE
BcValidationのテストを追加

### DIFF
--- a/plugins/baser-core/src/Model/Validation/BcValidation.php
+++ b/plugins/baser-core/src/Model/Validation/BcValidation.php
@@ -23,17 +23,17 @@ class BcValidation extends Validation {
      *
      * ハイフンアンダースコアを許容
      *
-     * @param array $check チェック対象文字列
-     * @param array $options 他に許容する文字列
+     * @param string $value チェック対象文字列
+     * @param array $context 他に許容する文字列
      * @return boolean
      */
-	public static function alphaNumericPlus($value, $context = []) {
+	public static function alphaNumericPlus($value, $context = null) {
 		if (!$value) {
 			return true;
 		}
-		if($context) {
+		if ($context) {
             if (is_array($context)) {
-                if(array_key_exists('data', $context)) {
+                if (array_key_exists('data', $context)) {
                     $context = [];
                 }
             } else {
@@ -51,8 +51,9 @@ class BcValidation extends Validation {
     /**
      * ２つのフィールド値を確認する
      *
-     * @param	array	$check 対象となる値
+     * @param	string	$value 対象となる値
      * @param	mixed	$fields フィールド名
+     * @param	array	$context
      * @return	boolean
      */
 	public static function confirm($value, $fields, $context) {
@@ -62,11 +63,18 @@ class BcValidation extends Validation {
 				isset($context['data'][$fields[1]])) {
 				$value1 = $context['data'][$fields[0]];
 				$value2 = $context['data'][$fields[1]];
+			} else {
+				return false;
 			}
 		} elseif ($fields) {
+			if (is_array($fields)) {
+				$fields = $fields[0];
+			}
 			if (isset($value) && isset($context['data'][$fields])) {
 				$value1 = $value;
 				$value2 = $context['data'][$fields];
+			} else {
+				return false;
 			}
 		} else {
 			return false;
@@ -84,26 +92,26 @@ class BcValidation extends Validation {
      * @return bool
      */
     public static function notEmptyMultiple($value, $context) {
-        if(isset($value['_ids'])) {
+        if (isset($value['_ids'])) {
             $value = $value['_ids'];
         }
-        if(!is_array($value)) {
+        if (!is_array($value)) {
             return false;
         }
-        foreach($value as $v) {
-            if($v) {
+        foreach ($value as $v) {
+            if ($v) {
                 return true;
             }
         }
         return false;
     }
 
-/**
- * 半角チェック
- *
- * @param array $check 確認する値を含む配列。先頭の要素のみチェックされる
- * @return boolean
- */
+    /**
+     * 半角チェック
+     *
+     * @param string $value 確認する値を含む配列
+     * @return boolean
+     */
     public static function halfText($value)
     {
         $len = strlen($value);

--- a/plugins/baser-core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -83,9 +83,10 @@ class UsersTableTest extends BcTestCase
      */
     public function testBeforeMarshal()
     {
-        $user = $this->Users->newEntity([
-            'password_1' => 'testtest'
-        ]);
+        $user = $this->Users->newEntity(
+            ['password_1' => 'testtest'],
+            ['validate' => false]
+        );
         $this->assertNotEmpty($user->password);
     }
 

--- a/plugins/baser-core/tests/TestCase/Model/Validation/BcValidationTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Validation/BcValidationTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <https://basercms.net>
+ * Copyright (c) baserCMS User Community <https://basercms.net/community/>
+ *
+ * @copyright     Copyright (c) baserCMS User Community
+ * @link          https://basercms.net baserCMS Project
+ * @since         5.0.0
+ * @license       http://basercms.net/license/index.html MIT License
+ */
+
+namespace BaserCore\Test\TestCase\Model\Validation;
+use BaserCore\Model\Validation\BcValidation;
+use BaserCore\TestSuite\BcTestCase;
+use Cake\Validation\Validator;
+
+/**
+ * Class BcValidationTest
+ * @package BaserCore\Test\TestCase\Model\Validation
+ * @property BcValidation $BcValidation
+ */
+class BcValidationTest extends BcTestCase {
+
+    /**
+     * Test subject
+     *
+     * @var BcValidation
+     */
+    public $BcValidation;
+
+    /**
+     * Set Up
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->BcValidation = new BcValidation();
+    }
+
+    /**
+     * Tear Down
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        unset($this->BcValidation);
+        parent::tearDown();
+    }
+
+    /**
+     * Test alphaNumericPlus
+     *
+     * @return void
+     */
+    public function testAlphaNumericPlus()
+    {
+        $alpha   = implode('', array_merge(range('a', 'z'), range('A', 'Z')));
+        $numeric = implode('', range(0, 9));
+        $mark    = '-_';
+        $allowedChars = $alpha.$numeric.$mark;
+
+        $this->assertEquals(true, $this->BcValidation->alphaNumericPlus(null));
+        $this->assertEquals(true, $this->BcValidation->alphaNumericPlus($allowedChars));
+        $this->assertEquals(false, $this->BcValidation->alphaNumericPlus($allowedChars.'!'));
+        $this->assertEquals(true, $this->BcValidation->alphaNumericPlus($allowedChars.'!', '!'));
+        $this->assertEquals(true, $this->BcValidation->alphaNumericPlus($allowedChars.'!', ['!']));
+    }
+
+    /**
+     * Test confirm
+     *
+     * @return void
+     */
+    public function testConfirm()
+    {
+        $context = [
+            'data' => [
+                'field0' => true,
+                'field1' => true,
+                'field2' => false
+            ]
+        ];
+
+        $this->assertEquals(true, $this->BcValidation->confirm(true, ['field0', 'field1'], $context));
+        $this->assertEquals(false, $this->BcValidation->confirm(true, ['field0', 'field2'], $context));
+        $this->assertEquals(false, $this->BcValidation->confirm(true, ['field0', 'nofield'], $context));
+        $this->assertEquals(true, $this->BcValidation->confirm(true, 'field0', $context));
+        $this->assertEquals(true, $this->BcValidation->confirm(true, ['field0'], $context));
+        $this->assertEquals(false, $this->BcValidation->confirm(true, 'field2', $context));
+        $this->assertEquals(false, $this->BcValidation->confirm(true, ['field2'], $context));
+        $this->assertEquals(false, $this->BcValidation->confirm(true, null, $context));
+    }
+
+    /**
+     * Test notEmptyMultiple
+     *
+     * @return void
+     */
+    public function testNotEmptyMultiple()
+    {
+        $value = [
+            '_ids' => [
+                'check0' => true,
+                'check1' => false
+            ],
+            'check2' => true,
+            'check3' => false
+        ];
+
+        $this->assertEquals(false, $this->BcValidation->notEmptyMultiple(['_ids' => true], []));
+        $this->assertEquals(false, $this->BcValidation->notEmptyMultiple('value', []));
+        $this->assertEquals(true, $this->BcValidation->notEmptyMultiple($value, []));
+
+        unset($value['_ids']['check0']);
+        $this->assertEquals(false, $this->BcValidation->notEmptyMultiple($value, []));
+
+        unset($value['_ids']);
+        $this->assertEquals(true, $this->BcValidation->notEmptyMultiple($value, []));
+
+        unset($value['check2']);
+        $this->assertEquals(false, $this->BcValidation->notEmptyMultiple($value, []));
+    }
+
+    /**
+     * Test halfText
+     *
+     * @return void
+     */
+    public function testHalfText()
+    {
+        $halfText = 'test';
+        $mbText = mb_convert_kana($halfText, 'A');
+
+        $this->assertEquals(true, $this->BcValidation->halfText($halfText));
+        $this->assertEquals(false, $this->BcValidation->halfText($mbText));
+    }
+}


### PR DESCRIPTION
下記の処理を追加いたしました。

1. テストに BcValidation のテストを追加
1. テストの UsersTable::beforeMarshal のテストを修正
1. BcValidation::alphaNumericPlus の引数のデフォルトを修正
1. BcValidation::confirm で指定したフィールドが存在しない時の結果を修正

2 のテストでは beforeMarshal の中で `$user->password` に値が入るかの確認でバリデーションの成否は別だと思うのでバリデーションを切っております。  
3 は $context がない場合に preg_match で Notice が出るので配列ではなく null にしております。  
4 は指定したフィールドが存在しない場合に2つの値は一致しないので false にしております。

ご確認よろしくお願いいたします！