### PR TITLE
ユーザー・ユーザーグループ編集 ヘルプテキスト表示調整

### DIFF
--- a/plugins/bc-admin-third/templates/element/Admin/UserGroups/form.php
+++ b/plugins/bc-admin-third/templates/element/Admin/UserGroups/form.php
@@ -62,13 +62,13 @@ $(window).load(function() {
                     <?php echo $this->BcAdminForm->control('name', ['type' => 'text', 'size' => 20, 'maxlength' => 255, 'autofocus' => true]) ?>
                 <?php endif ?>
                 <i class="bca-icon--question-circle btn help bca-help"></i>
-                <?php echo $this->BcAdminForm->error('name') ?>
                 <div id="helptextName" class="helptext">
                     <ul>
                         <li><?php echo __d('baser', '重複しない識別名称を半角のみで入力してください。') ?></li>
                         <li><?php echo __d('baser', 'admins の場合は変更できません。') ?></li>
                     </ul>
                 </div>
+                <?php echo $this->BcAdminForm->error('name') ?>
             </td>
         </tr>
         <tr>

--- a/plugins/bc-admin-third/templates/element/Admin/Users/form.php
+++ b/plugins/bc-admin-third/templates/element/Admin/Users/form.php
@@ -53,8 +53,8 @@ $this->BcBaser->i18nScript([
             <td class="col-input bca-form-table__input">
                 <?php echo $this->BcAdminForm->control('name', ['type' => 'text', 'size' => 20, 'maxlength' => 255, 'autofocus' => true]) ?>
                 <i class="bca-icon--question-circle btn help bca-help"></i>
-                <?php echo $this->BcAdminForm->error('name') ?>
                 <div id="helptextName" class="helptext"><?php echo __d('baser', '半角英数字とハイフン、アンダースコアのみで入力してください。') ?></div>
+                <?php echo $this->BcAdminForm->error('name') ?>
             </td>
         </tr>
         <tr>
@@ -63,9 +63,9 @@ $this->BcBaser->i18nScript([
                 <small>[<?php echo __d('baser', '姓') ?>]</small> <?php echo $this->BcAdminForm->control('real_name_1', ['type' => 'text', 'size' => 12, 'maxlength' => 255]) ?>
                 <small>[<?php echo __d('baser', '名') ?>]</small> <?php echo $this->BcAdminForm->control('real_name_2', ['type' => 'text', 'size' => 12, 'maxlength' => 255]) ?>
                 <i class="bca-icon--question-circle btn help bca-help"></i>
+                <div id="helptextRealName1" class="helptext"><?php echo __d('baser', '「名」は省略する事ができます。') ?></div>
                 <?php echo $this->BcAdminForm->error('real_name_1', __d('baser', '姓を入力してください')) ?>
                 <?php echo $this->BcAdminForm->error('real_name_2', __d('baser', '名を入力してください')) ?>
-                <div id="helptextRealName1" class="helptext"><?php echo __d('baser', '「名」は省略する事ができます。') ?></div>
             </td>
         </tr>
         <tr>
@@ -73,8 +73,8 @@ $this->BcBaser->i18nScript([
             <td class="col-input bca-form-table__input">
                 <?php echo $this->BcAdminForm->control('nickname', ['type' => 'text', 'size' => 40, 'maxlength' => 255]) ?>
                 <i class="bca-icon--question-circle btn help bca-help"></i>
-                <?php echo $this->BcAdminForm->error('nickname') ?>
                 <div id="helptextNickname" class="helptext"><?php echo __d('baser', 'ニックネームを設定している場合は全ての表示にニックネームが利用されます。') ?></div>
+                <?php echo $this->BcAdminForm->error('nickname') ?>
             </td>
         </tr>
         <tr>
@@ -97,11 +97,11 @@ $this->BcBaser->i18nScript([
                 <input type="text" name="dummy-email" style="top:-100px;left:-100px;position:fixed;">
                 <?php echo $this->BcAdminForm->control('email', ['type' => 'text', 'size' => 40, 'maxlength' => 255]) ?>
                 <i class="bca-icon--question-circle btn help bca-help"></i>
-                <?php echo $this->BcAdminForm->error('email') ?>
                 <div id="helptextEmail" class="helptext">
                     <?php echo __d('baser', '連絡用メールアドレスを入力します。') ?>
                     <br><small>※ <?php echo __d('baser', 'パスワードを忘れた場合の新パスワードの通知先等') ?></small>
                 </div>
+                <?php echo $this->BcAdminForm->error('email') ?>
             </td>
         </tr>
         <tr>
@@ -118,7 +118,6 @@ $this->BcBaser->i18nScript([
                 <?php echo $this->BcAdminForm->control('password_1', ['type' => 'password', 'size' => 20, 'maxlength' => 255, 'autocomplete' => 'off']) ?>
                 <?php echo $this->BcAdminForm->control('password_2', ['type' => 'password', 'size' => 20, 'maxlength' => 255, 'autocomplete' => 'off']) ?>
                 <i class="bca-icon--question-circle btn help bca-help"></i>
-                <?php echo $this->BcAdminForm->error('password') ?>
                 <div id="helptextPassword" class="helptext">
                     <ul>
                         <li>
@@ -130,6 +129,7 @@ $this->BcBaser->i18nScript([
                         <li><?php echo __d('baser', '最低６文字以上で入力してください') ?></li>
                     </ul>
                 </div>
+                <?php echo $this->BcAdminForm->error('password') ?>
             </td>
         </tr>
         <?php echo $this->BcAdminForm->dispatchAfterForm() ?>


### PR DESCRIPTION
ユーザー追加・編集 と ユーザーグループ追加・編集 画面において、バリデーションエラーが発生した際にヘルプテキストが表示されない問題を修正しました。

<img width="1041" alt="スクリーンショット 2021-01-23 14 42 54" src="https://user-images.githubusercontent.com/30764014/105569925-51404000-5d89-11eb-8754-5081503b4276.png">

ヘルプアイコンの隣にヘルプテキストの要素を配置する必要があったため、ヘルプテキスト要素の移動で対応しました。

baser4にも同様の問題がありますが、ucmitzと違い対象箇所が多いためいったんissueだけ作成しておきます。