### PR TITLE
キャッシュエンジン設定時に構築済み設定の削除処理を追加

### DIFF
--- a/plugins/baser-core/config/bootstrap.php
+++ b/plugins/baser-core/config/bootstrap.php
@@ -25,6 +25,9 @@ Validator::addDefaultProvider('bc', 'BaserCore\Model\Validation\BcValidation');
 /**
  * キャッシュ
  */
+if (Cache::getConfig('_cake_env_')) {
+    Cache::drop('_cake_env_');
+}
 Cache::setConfig(Configure::consume('Cache'));
 
 /**


### PR DESCRIPTION
下記の処理を実装いたしました。
- bootstrap でキャッシュエンジン設定時に `_cake_env_` キーが設定済みの場合直前に削除

キャッシュエンジンを設定する際、既に構築済みのキーを設定しようとするとエラーになります。テストで複数回処理が呼ばれる際にこの現象が起きていました。  
初回の `Configure::consume('Cache')` で `StaticConfigTrait::$_config['_cake_env_']` が設定されますが、2回目以降は既に `StaticConfigTrait::$_config['_cake_env_']` が存在し重複するので例外がスローされているようです。その為、設定直前に `_cake_env_` キーが存在する場合は削除するようにいたしました。  

対応方法や処理タイミング等確認していただけると助かります。  
お手数ですがご確認よろしくお願いいたします！