### PR TITLE
vagrantでもXdebug3.0が動く様に調整

### DIFF
--- a/docker/dockerfile/Dockerfile-php7.3
+++ b/docker/dockerfile/Dockerfile-php7.3
@@ -46,10 +46,12 @@ RUN echo 'sendmail_path = "/usr/sbin/ssmtp -t"' > /usr/local/etc/php/conf.d/mail
     && echo "date.timezone = Asia/Tokyo" >> /usr/local/etc/php/php.ini \
 	&& yes | pecl install xdebug mcrypt-1.0.2 \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.mode = debug,develop" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.client_port = 9003" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.client_host = 10.0.2.2" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.discover_client_host=1" >> /usr/local/etc/php/conf.d/xdebug.ini \
+	&& echo "xdebug.idekey=BASERCMS" >> /usr/local/etc/php/conf.d/xdebug.ini \
+	&& echo "xdebug.client_host=10.0.2.2" >> /usr/local/etc/php/conf.d/xdebug.ini \
+	&& echo "xdebug.client_port=9000" >> /usr/local/etc/php/conf.d/xdebug.ini \
+	&& echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/xdebug.ini \
+	&& echo "xdebug.mode=debug,develop" >> /usr/local/etc/php/conf.d/xdebug.ini 
     && echo "extension=mcrypt.so" >> /usr/local/etc/php/conf.d/mcrypt.ini
     
 # ssmtp

--- a/docker/dockerfile/Dockerfile-php7.3
+++ b/docker/dockerfile/Dockerfile-php7.3
@@ -46,9 +46,10 @@ RUN echo 'sendmail_path = "/usr/sbin/ssmtp -t"' > /usr/local/etc/php/conf.d/mail
     && echo "date.timezone = Asia/Tokyo" >> /usr/local/etc/php/php.ini \
 	&& yes | pecl install xdebug mcrypt-1.0.2 \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_host=10.0.2.2" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.mode = debug,develop" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.client_port = 9003" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.client_host = 10.0.2.2" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "extension=mcrypt.so" >> /usr/local/etc/php/conf.d/mcrypt.ini
     
 # ssmtp


### PR DESCRIPTION
dockerのデフォルトの設定では、phpのコンテナに`baserproject/basercms:5-php7.3`が使われている様ですが、
こちらのxdebugの設定が`xdebug.remote_host = host.docker.internal`となっており、vagrant環境で動きませんでした。
対処として、`docker/dockerfile/Dockerfile-php7.3`を
```
container_name: bc5-php
    #image: baserproject/basercms:5-php7.3
    build:
      context: ./
      dockerfile: ./dockerfile/Dockerfile-php7.3
```
としてビルドしてみたところ、xdebugのバージョンが３にアップデートされていてこちらもリモートデバッグが動かなかったので、XDebug3環境でデバッグを動かすための設定を調整致しました。

確認よろしくお願いいたします。

**参考**
[docker on vagrant環境でXdebug3をvscodeから動かす方法](https://zenn.dev/diwamoto/articles/3c6117e9157900)
[Xdebug: Documentation » Upgrading from Xdebug 2 to 3](https://xdebug.org/docs/upgrade_guide)