### PR TITLE
composer install に失敗する場合の対応を追加

### DIFF
--- a/docs/preparation/setup.md
+++ b/docs/preparation/setup.md
@@ -16,6 +16,7 @@ vagrant ssh
 cd /vagrant/docker
 docker exec -it bc5-php /bin/bash
 composer install
+# エラーが出る場合は composer install --no-plugins を実行する
 ```
 
 　


### PR DESCRIPTION
setup.mdに、composer install に失敗する場合の対応方法を追記しています。
ご確認お願いします。


■参考
https://scrapbox.io/kadoyau/composer_install%E3%81%A7Could_not_delete%E3%81%A8%E3%81%84%E3%82%8F%E3%82%8C%E3%80%81clear-cache%E3%81%97%E3%81%A6%E3%82%82%E3%81%AA%E3%81%8A%E3%82%89%E3%81%AA%E3%81%84%E3%81%A8%E3%81%8D%E3%81%AFcomposer_update_--no-plugins%E3%82%92%E3%81%99%E3%82%8B
https://qiita.com/tristar/items/a7447c4ae5332646d7fe
