### PR TITLE
getDirectoryPath()をCake\Core\Plugin::path()に変更

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,6 +54,7 @@ baserCMS4で利用しているCakePHP2系からCakePHP4系に移行するにあ�
 - [リクエスト関連における注意点](https://github.com/baserproject/ucmitz/blob/dev/docs/development/migration_point/request.md)
 - [セッション関連における注意点](https://github.com/baserproject/ucmitz/blob/dev/docs/development/migration_point/session.md)
 - [データベースにおける注意点](https://github.com/baserproject/ucmitz/blob/dev/docs/development/migration_point/database.md)
+- [プラグインにおける注意点](https://github.com/baserproject/ucmitz/blob/dev/docs/development/migration_point/database.md)
 
 　
 ### テーマの開発

--- a/docs/basic/architecture_design_policy.md
+++ b/docs/basic/architecture_design_policy.md
@@ -138,3 +138,5 @@ class UsersController extends BcApiController
     }
 }
 ```
+### 参考
+https://book.cakephp.org/4/ja/development/dependency-injection.html

--- a/docs/development/migration_point/plugin.md
+++ b/docs/development/migration_point/plugin.md
@@ -1,0 +1,7 @@
+# プラグインにおける注意点
+
+## メソッドの変更点
+
+```
+getDirectoryPath($pluginName) → Cake\Core\Plugin::path($pluginName)
+```

--- a/plugins/baser-core/src/Controller/BcFormController.php
+++ b/plugins/baser-core/src/Controller/BcFormController.php
@@ -26,6 +26,7 @@ class BcFormController extends AppController
 	 *
 	 * @return mixed
      * @checked
+	 * @unitTest
      * @noTodo
 	 */
 	public function get_token()

--- a/plugins/baser-core/src/Model/Table/PluginsTable.php
+++ b/plugins/baser-core/src/Model/Table/PluginsTable.php
@@ -15,6 +15,7 @@ use BaserCore\Error\BcException;
 use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Utility\BcUtil;
 use Cake\Core\App;
+use Cake\Core\Plugin;
 use Cake\Core\Configure;
 use Cake\Filesystem\Folder;
 use Cake\ORM\Table;
@@ -429,29 +430,6 @@ class PluginsTable extends Table
     }
 
     /**
-     * プラグインのディレクトリパスを取得
-     *
-     * @param string $pluginName プラグイン名
-     * @return string|null
-     * @checked
-     * @noTodo
-     */
-    public function getDirectoryPath($pluginName)
-    {
-        $paths = App::path('Plugin');
-        foreach($paths as $path) {
-            $Folder = new Folder($path);
-            $files = $Folder->read(true, true, true);
-            foreach($files[0] as $dir) {
-                if (basename($dir) === $pluginName) {
-                    return $dir;
-                }
-            };
-        }
-        return null;
-    }
-
-    /**
      * プラグイン情報を取得する
      *
      * @param array $datas プラグインのデータ配列
@@ -555,7 +533,7 @@ class PluginsTable extends Table
     public function addFavoriteAdminLink($pluginName, $user)
     {
         $plugin = $this->findByName($pluginName);
-        $dirPath = $this->getDirectoryPath($pluginName);
+        $dirPath = Plugin::path($pluginName);
         $pluginInfo = $this->getPluginInfo([$plugin], $dirPath);
 
         //リンクが設定されていない

--- a/plugins/baser-core/tests/TestCase/Model/Table/_NotYetMigrated/PluginTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/_NotYetMigrated/PluginTest.php
@@ -203,33 +203,6 @@ class PluginTest extends BaserTestCase
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 
-
-	/**
-	 * プラグインのディレクトリパスを取得
-	 *
-	 * @param string $pluginName プラグイン名
-	 * @param array $expected 期待値
-	 * @param string $message テストが失敗した時に表示されるメッセージ
-	 * @dataProvider getDirectoryPathDataProvider
-	 */
-	public function testGetDirectoryPath($pluginName, $expected, $message = null)
-	{
-		if (!is_null($expected)) {
-			$expected = BASER_PLUGINS . $expected;
-		}
-		$result = $this->Plugin->getDirectoryPath($pluginName);
-		$this->assertEquals($expected, $result, $message);
-	}
-
-	public function getDirectoryPathDataProvider()
-	{
-		return [
-			['Blog', 'Blog', 'プラグインのディレクトリパスを取得できません'],
-			['Feed', 'Feed', 'プラグインのディレクトリパスを取得できません'],
-			['hoge', null, '存在しないプラグインです'],
-		];
-	}
-
 	/**
 	 * プラグイン情報を取得する
 	 *


### PR DESCRIPTION
- getDirectoryPath()とCake\Core\Plugin::path()は同じことをしてるので、getDirectoryPath()削除したいんですけど大丈夫そうですか?

- get_token　アノテーション追加
- DIコンテナのページ日本語翻訳したので、関係性あると思うので一応追加しておきました。