### PR TITLE
getJsonMenuの切り分けとテスト

### DIFF
--- a/plugins/baser-core/src/Utility/BcUtil.php
+++ b/plugins/baser-core/src/Utility/BcUtil.php
@@ -325,7 +325,7 @@ class BcUtil
      * @param string $prefix ログイン認証プレフィックス
      * @return bool|mixed ユーザーグループ情報
      */
-    public static function loginUserGroup($prefix = 'admin')
+    public static function loginUserGroup($prefix = 'Admin')
     {
         $loginUser = self::loginUser($prefix);
         if (!empty($loginUser['UserGroup'])) {

--- a/plugins/baser-core/src/View/Helper/BcAdminHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcAdminHelper.php
@@ -112,6 +112,7 @@ class BcAdminHelper extends Helper
 
     /**
      * 管理画面のメニューに変更を加える
+     * @todo 整理する必要あり
      * @return array
      */
     public function convertAdminMenuGroups($adminMenuGroups)
@@ -197,7 +198,6 @@ class BcAdminHelper extends Helper
                 $covertedAdminMenuGroups[] = $adminMenuGroup;
             }
         }
-
         if ($currentOn === false) {
             foreach($covertedAdminMenuGroups as $key => $adminMenuGroup) {
                 if (!empty($adminMenuGroup['disable']) && $adminMenuGroup['disable'] === true) {

--- a/plugins/baser-core/src/View/Helper/BcAdminHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcAdminHelper.php
@@ -39,76 +39,80 @@ class BcAdminHelper extends Helper
      */
     public $helpers = ['BcBaser'];
 
-	/**
-	 * 管理システムグローバルメニューの利用可否確認
-	 *
-	 * @return bool
-	 */
-	public function isAdminGlobalmenuUsed()
-	{
-	    return true;
-	    // TODO 要コード確認
-	    /* >>>
-		if (!BC_INSTALLED) {
-			return false;
-		}
-		if (Configure::read('BcRequest.isUpdater')) {
-			return false;
-		}
-		$user = $this->_View->get('user');
-		if (!$user) {
-			return false;
-		}
-		$UserGroup = ClassRegistry::init('UserGroup');
-		return $UserGroup->isAdminGlobalmenuUsed($user['user_group_id']);
-	    <<< */
-	}
-
-	/**
-	 * ログインユーザーがシステム管理者かチェックする
-	 *
-	 * @return boolean
-	 */
-	public function isSystemAdmin()
-	{
-		$user = $this->_View->getVar('user');
-		if ($this->request->getParam['prefix'] === 'Admin' || !$user) {
-			return false;
-		}
-		if ($user['user_group_id'] == Configure::read('BcApp.adminGroupId')) {
-			return true;
-		}
-		return false;
-	}
+    /**
+     * 管理システムグローバルメニューの利用可否確認
+     *
+     * @return bool
+     */
+    public function isAdminGlobalmenuUsed()
+    {
+        return true;
+        // TODO 要コード確認
+        /* >>>
+        if (!BC_INSTALLED) {
+            return false;
+        }
+        if (Configure::read('BcRequest.isUpdater')) {
+            return false;
+        }
+        $user = $this->_View->get('user');
+        if (!$user) {
+            return false;
+        }
+        $UserGroup = ClassRegistry::init('UserGroup');
+        return $UserGroup->isAdminGlobalmenuUsed($user['user_group_id']);
+        <<< */
+    }
 
     /**
-     * JSON形式でメニューデータを取得する
-     * # siteId の仕様
-     * - null：全てのサイトで表示
-     * - 数値：対象のサイトのみ表示（javascript で扱いやすいよう文字列に変換）
-     * @return string
-     * @checked
+     * ログインユーザーがシステム管理者かチェックする
+     *
+     * @return boolean
      */
-    public function getJsonMenu()
+    public function isSystemAdmin()
+    {
+        $user = $this->_View->getVar('user');
+        if ($this->request->getParam['prefix'] === 'Admin' || !$user) {
+            return false;
+        }
+        if ($user['user_group_id'] == Configure::read('BcApp.adminGroupId')) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 管理画面のメニューを取得する
+     * @return array|false
+     */
+    protected function getAdminMenuGroups()
     {
         $adminMenuGroups = Configure::read('BcApp.adminNavigation');
 
-        $currentSiteId = (string)$this->_View->getRequest()
-            ->getSession()
-            ->read('Baser.viewConditions.ContentsAdminIndex.named.site_id');
-
-        if (!$adminMenuGroups) {
-            return null;
-        }
-        // TODO : 要実装
-//		if(empty($this->_View->viewVars['user']['user_group_id'])) {
-//			return null;
-//		}
-        if (!is_null($currentSiteId) && $currentSiteId) {
-            $currentSiteId = (string)$currentSiteId;
+        if($adminMenuGroups) {
+            $contents = $adminMenuGroups['Contents'];
+            $systems = $adminMenuGroups['Systems'];
+            $plugins = $adminMenuGroups['Plugins'] ?? [];
+    
+            unset($adminMenuGroups['Contents'], $adminMenuGroups['Systems'], $adminMenuGroups['Plugins']);
+            if ($plugins) {
+                foreach($plugins['menus'] as $plugin) {
+                    $systems['Plugin']['menus'][] = $plugin;
+                }
+            }
+            $adminMenuGroups = $contents + $adminMenuGroups + $systems;
+            return $adminMenuGroups;
         } else {
-            $currentSiteId = "0";
+            return false;
         }
+    }
+
+    /**
+     * 管理画面のメニューに変更を加える
+     * @return array
+     */
+    protected function convertAdminMenuGroups($adminMenuGroups)
+    {
         $request = $this->_View->getRequest();
         $base = $request->getAttributes()['base'];
         $url = $request->getUri();
@@ -121,18 +125,8 @@ class BcAdminHelper extends Helper
         if ($params) {
             $currentUrl .= '?' . $params;
         }
-        $contents = $adminMenuGroups['Contents'];
-        $systems = $adminMenuGroups['Systems'];
-        $plugins = (isset($adminMenuGroups['Plugins']))? $adminMenuGroups['Plugins'] : [];
-        unset($adminMenuGroups['Contents'], $adminMenuGroups['Systems'], $adminMenuGroups['Plugins']);
-        if ($plugins) {
-            foreach($plugins['menus'] as $plugin) {
-                $systems['Plugin']['menus'][] = $plugin;
-            }
-        }
-        $adminMenuGroups = $contents + $adminMenuGroups + $systems;
         // TODO 要実装
-//		$Permission = ClassRegistry::init('Permission');
+        // $Permission = ClassRegistry::init('Permission');
         $covertedAdminMenuGroups = [];
         $currentOn = false;
         foreach($adminMenuGroups as $group => $adminMenuGroup) {
@@ -223,11 +217,39 @@ class BcAdminHelper extends Helper
             }
         }
 
+        return $covertedAdminMenuGroups;
+    }
+
+    /**
+     * JSON形式でメニューデータを取得する
+     * # siteId の仕様
+     * - null：全てのサイトで表示
+     * - 数値：対象のサイトのみ表示（javascript で扱いやすいよう文字列に変換）
+     * @return string
+     * @checked
+     */
+    public function getJsonMenu()
+    {       
+        $adminMenuGroups = $this->getAdminMenuGroups();
+        if($adminMenuGroups === false) return null;
+
+        // TODO : 要実装 BcUtil::loginUserGroup()で代用可能?
+        // if(empty($this->_View->viewVars['user']['user_group_id'])) {
+        //     return null;
+        // }
+
+        $currentSiteId = (string)$this->_View->getRequest()
+        ->getSession()
+        ->read('Baser.viewConditions.ContentsAdminIndex.named.site_id');
+
+        $currentSiteId = $currentSiteId ? (string)$currentSiteId : "0";
+
+        $covertedAdminMenuGroups = $this->convertAdminMenuGroups($adminMenuGroups);
+
         $menuSettings = [
             'currentSiteId' => $currentSiteId,
             'menuList' => $covertedAdminMenuGroups
         ];
-
         return json_encode($menuSettings);
     }
 

--- a/plugins/baser-core/src/View/Helper/BcAdminHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcAdminHelper.php
@@ -121,6 +121,7 @@ class BcAdminHelper extends Helper
         $url = $request->getUri();
         $currentUrl = '/' . $url;
         $params = null;
+        
         if (strpos($currentUrl, '?') !== false) {
             [$currentUrl, $params] = explode('?', $currentUrl);
         }
@@ -230,6 +231,7 @@ class BcAdminHelper extends Helper
      * - 数値：対象のサイトのみ表示（javascript で扱いやすいよう文字列に変換）
      * @return string
      * @checked
+     * @unitTest
      */
     public function getJsonMenu()
     {       
@@ -241,11 +243,14 @@ class BcAdminHelper extends Helper
         //     return null;
         // }
 
-        $currentSiteId = (string)$this->_View->getRequest()
-        ->getSession()
-        ->read('Baser.viewConditions.ContentsAdminIndex.named.site_id');
+        // TODO: $currentSiteIdで"0"以外の値が読み込まれる場所が見当たらないため一旦"0"代入で代用
 
-        $currentSiteId = $currentSiteId ? (string)$currentSiteId : "0";
+        // $currentSiteId = (string)$this->_View->getRequest()
+        //                 ->getSession()
+        //                 ->read('Baser.viewConditions.ContentsAdminIndex.named.site_id');
+
+        // $currentSiteId = $currentSiteId ? (string)$currentSiteId : "0";
+        $currentSiteId = "0";
 
         $covertedAdminMenuGroups = $this->convertAdminMenuGroups($adminMenuGroups);
 

--- a/plugins/baser-core/src/View/Helper/BcAdminHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcAdminHelper.php
@@ -84,8 +84,11 @@ class BcAdminHelper extends Helper
     /**
      * 管理画面のメニューを取得する
      * @return array|false
+     * @checked
+     * @unitTest
+     * @noTodo
      */
-    protected function getAdminMenuGroups()
+    public function getAdminMenuGroups()
     {
         $adminMenuGroups = Configure::read('BcApp.adminNavigation');
 
@@ -111,7 +114,7 @@ class BcAdminHelper extends Helper
      * 管理画面のメニューに変更を加える
      * @return array
      */
-    protected function convertAdminMenuGroups($adminMenuGroups)
+    public function convertAdminMenuGroups($adminMenuGroups)
     {
         $request = $this->_View->getRequest();
         $base = $request->getAttributes()['base'];

--- a/plugins/baser-core/src/View/Helper/BcAdminHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcAdminHelper.php
@@ -88,7 +88,7 @@ class BcAdminHelper extends Helper
      * @unitTest
      * @noTodo
      */
-    public function getAdminMenuGroups()
+    private function getAdminMenuGroups()
     {
         $adminMenuGroups = Configure::read('BcApp.adminNavigation');
 
@@ -115,7 +115,7 @@ class BcAdminHelper extends Helper
      * @todo 整理する必要あり
      * @return array
      */
-    public function convertAdminMenuGroups($adminMenuGroups)
+    private function convertAdminMenuGroups($adminMenuGroups)
     {
         $request = $this->_View->getRequest();
         $base = $request->getAttributes()['base'];
@@ -242,15 +242,10 @@ class BcAdminHelper extends Helper
         // if(empty($this->_View->viewVars['user']['user_group_id'])) {
         //     return null;
         // }
-
-        // TODO: $currentSiteIdで"0"以外の値が読み込まれる場所が見当たらないため一旦"0"代入で代用
-
-        // $currentSiteId = (string)$this->_View->getRequest()
-        //                 ->getSession()
-        //                 ->read('Baser.viewConditions.ContentsAdminIndex.named.site_id');
-
-        // $currentSiteId = $currentSiteId ? (string)$currentSiteId : "0";
-        $currentSiteId = "0";
+        $currentSiteId = (string)$this->_View->getRequest()
+                        ->getSession()
+                        ->read('Baser.viewConditions.ContentsAdminIndex.named.site_id');
+        $currentSiteId = $currentSiteId ? (string)$currentSiteId : "0";
 
         $covertedAdminMenuGroups = $this->convertAdminMenuGroups($adminMenuGroups);
 

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcAdminHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcAdminHelperTest.php
@@ -209,8 +209,18 @@ class BcAdminHelperTest extends BcTestCase
      */
     public function testGetJsonMenu(): void
     {
-        $jsonMenu = $this->BcAdmin->getJsonMenu();
-        echo $jsonMenu;
+        $jsonMenu = json_decode($this->BcAdmin->getJsonMenu());
+        // $currentSiteIdのテスト
+        $this->assertEquals($jsonMenu->currentSiteId, "0");
+        // $menuListに項目が入ってるかテスト
+        $adminMenuGroups = $this->BcAdmin->getAdminMenuGroups();
+        foreach($jsonMenu->menuList as $menuList) {
+            $this->assertContains($menuList->name, array_keys($adminMenuGroups));
+        }
+        // adminNavigationがnullの場合 nullが返る
+        Configure::write('BcApp.adminNavigation', null);
+        $this->assertNull(json_decode($this->BcAdmin->getJsonMenu()));
+
     }
 
     /**

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcAdminHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcAdminHelperTest.php
@@ -200,6 +200,8 @@ class BcAdminHelperTest extends BcTestCase
      */
     public function testConvertAdminMenuGroups(): void
     {
+        // $adminMenuGroups = $this->BcAdmin->getAdminMenuGroups();
+        // $covertedAdminMenuGroups = $this->BcAdmin->convertAdminMenuGroups($adminMenuGroups);
         $this->markTestIncomplete('Not implemented yet.');
     }
 

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcAdminHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcAdminHelperTest.php
@@ -179,6 +179,15 @@ class BcAdminHelperTest extends BcTestCase
     }
 
     /**
+     * Test getJsonMenu
+     * @return void
+     */
+    public function testGetJsonMenu() {
+        $jsonMenu = $this->BcAdmin->getJsonMenu();
+        echo $jsonMenu;
+    }
+
+    /**
      * Test contentsMenu
      *
      * @return void

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcAdminHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcAdminHelperTest.php
@@ -15,6 +15,7 @@ use BaserCore\TestSuite\BcTestCase;
 use Cake\Core\Configure;
 use BaserCore\View\BcAdminAppView;
 use BaserCore\View\Helper\BcAdminHelper;
+use ReflectionClass;
 
 /**
  * Class BcAdminHelperTest
@@ -33,7 +34,7 @@ class BcAdminHelperTest extends BcTestCase
         'plugin.BaserCore.UserGroups',
     ];
 
-   /**
+    /**
      * setUp method
      *
      * @return void
@@ -185,13 +186,17 @@ class BcAdminHelperTest extends BcTestCase
      */
     public function testGetAdminMenuGroups(): void
     {
-        $adminMenuGroups = $this->BcAdmin->getAdminMenuGroups();
+        $ref = new ReflectionClass($this->BcAdmin);
+        $method = $ref->getMethod('getAdminMenuGroups');
+        $method->setAccessible(true);        
+        $adminMenuGroups = $method->invokeArgs($this->BcAdmin, []);
+        // それぞれのメニューキーを持つか
         $this->assertArrayHasKey('Dashboard', $adminMenuGroups);
         $this->assertArrayHasKey('Users', $adminMenuGroups);
         $this->assertArrayHasKey('Plugin', $adminMenuGroups);
         // adminNavigationがない場合
         Configure::write('BcApp.adminNavigation', null);
-        $this->assertFalse($this->BcAdmin->getAdminMenuGroups());
+        $this->assertFalse($method->invokeArgs($this->BcAdmin, []));
     }
 
     /**
@@ -214,8 +219,12 @@ class BcAdminHelperTest extends BcTestCase
         $jsonMenu = json_decode($this->BcAdmin->getJsonMenu());
         // $currentSiteIdのテスト
         $this->assertEquals($jsonMenu->currentSiteId, "0");
+        // $adminMenuGroupsの取得
+        $ref = new ReflectionClass($this->BcAdmin);
+        $method = $ref->getMethod('getAdminMenuGroups');
+        $method->setAccessible(true);  
+        $adminMenuGroups = $method->invokeArgs($this->BcAdmin, []);
         // $menuListに項目が入ってるかテスト
-        $adminMenuGroups = $this->BcAdmin->getAdminMenuGroups();
         foreach($jsonMenu->menuList as $menuList) {
             $this->assertContains($menuList->name, array_keys($adminMenuGroups));
         }

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcAdminHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcAdminHelperTest.php
@@ -12,6 +12,7 @@
 namespace BaserCore\Test\TestCase\View\Helper;
 
 use BaserCore\TestSuite\BcTestCase;
+use Cake\Core\Configure;
 use BaserCore\View\BcAdminAppView;
 use BaserCore\View\Helper\BcAdminHelper;
 
@@ -179,10 +180,35 @@ class BcAdminHelperTest extends BcTestCase
     }
 
     /**
+     * Test getAdminMenuGroups
+     * @return void
+     */
+    public function testGetAdminMenuGroups(): void
+    {
+        $adminMenuGroups = $this->BcAdmin->getAdminMenuGroups();
+        $this->assertArrayHasKey('Dashboard', $adminMenuGroups);
+        $this->assertArrayHasKey('Users', $adminMenuGroups);
+        $this->assertArrayHasKey('Plugin', $adminMenuGroups);
+        // adminNavigationがない場合
+        Configure::write('BcApp.adminNavigation', null);
+        $this->assertFalse($this->BcAdmin->getAdminMenuGroups());
+    }
+
+    /**
+     * Test convertAdminMenuGroups
+     * @return void
+     */
+    public function testConvertAdminMenuGroups(): void
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
      * Test getJsonMenu
      * @return void
      */
-    public function testGetJsonMenu() {
+    public function testGetJsonMenu(): void
+    {
         $jsonMenu = $this->BcAdmin->getJsonMenu();
         echo $jsonMenu;
     }


### PR DESCRIPTION
getJsonMenuを
getAdminMenuGroups・convertAdminMenuGroups・getJsonMenuの３つのメソッドに切り分け
convertAdminMenuGroupsに関してはテストがかけてません。

 isAdminGlobalmenuUsed・isSystemAdminはただのインデント変更です。