### PR TITLE
BcAppControllerTestの型だけ追加

### DIFF
--- a/plugins/baser-core/src/Controller/BcAppController.php
+++ b/plugins/baser-core/src/Controller/BcAppController.php
@@ -196,10 +196,10 @@ class BcAppController extends AppController
     )
     {
         parent::__construct($request, $response, $name, $eventManager, $components);
-
-        if (BcUtil::isConsole()) {
-            unset($this->components['Session']);
-        }
+        // TODO $componentsが未定義のため一旦コメントアウト
+        // if (BcUtil::isConsole()) {
+        //     unset($this->components['Session']);
+        // }
         // TODO siteConfigs代替措置
         // $config = $this->getTableLocator()->exists('SiteConfigs')? [] : ['className' => 'BaserCore\Model\Table\SiteConfigsTable'];
         // $this->siteConfigs = TableRegistry::getTableLocator()->get('SiteConfigs');

--- a/plugins/baser-core/src/Utility/BcUtil.php
+++ b/plugins/baser-core/src/Utility/BcUtil.php
@@ -564,12 +564,14 @@ class BcUtil
      * コンソールから実行されているかチェックする
      *
      * @return bool
+     * @checked
+     * @unitTest
      */
     public static function isConsole()
     {
         // TODO isConsoleのCAKEPHP_SHELLが非推奨&&未定義のため代替措置
         // return defined('CAKEPHP_SHELL') && CAKEPHP_SHELL;
-        return substr(php_sapi_name(), 0, 3) == 'cgi';
+        return substr(php_sapi_name(), 0, 3) == 'cli';
 
     }
 

--- a/plugins/baser-core/tests/TestCase/Controller/BcAppControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/BcAppControllerTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <https://basercms.net>
+ * Copyright (c) baserCMS User Community <https://basercms.net/community/>
+ *
+ * @copyright     Copyright (c) baserCMS User Community
+ * @link          https://basercms.net baserCMS Project
+ * @since         5.0.0
+ * @license       http://basercms.net/license/index.html MIT License
+ */
+
+namespace BaserCore\Test\TestCase\Controller;
+
+use Cake\TestSuite\IntegrationTestTrait;
+use BaserCore\TestSuite\BcTestCase;
+use BaserCore\Controller\BcAppController;
+use Cake\Event\Event;
+
+/**
+ * BaserCore\Controller\BcAppController Test Case
+ */
+class BcAppControllerTest extends BcTestCase
+{
+    use IntegrationTestTrait;
+
+    /**
+     * set up
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->BcAppController = new BcAppController($this->getRequest());
+    }
+
+    /**
+     * Tear Down
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->BcAppController);
+    }
+
+    /**
+     * Test construct
+     *
+     * @return void
+     */
+    public function testConstruct(): void
+    {
+        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+    }
+
+    /**
+     * Test beforeFilter
+     *
+     * @return void
+     */
+    public function testBeforeFilter(): void
+    {
+        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+    }
+
+}

--- a/plugins/baser-core/tests/TestCase/Utility/BcUtilTest.php
+++ b/plugins/baser-core/tests/TestCase/Utility/BcUtilTest.php
@@ -598,7 +598,8 @@ class BcUtilTest extends BcTestCase
      */
     public function testIsConsole()
     {
-        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+        // テストはCliから実行するためtrue
+        $this->assertTrue(BcUtil::isConsole());
     }
 
     /**


### PR DESCRIPTION
 - $componentsが未定義のため一旦コメントアウトBcUtil::isConsole()の部分
BcAppControllerTestの内部テストはまだ出来そうにないので、markIncompleteしました