### PR TITLE
execPrivateMethod作成

### DIFF
--- a/plugins/baser-core/src/TestSuite/BcTestCase.php
+++ b/plugins/baser-core/src/TestSuite/BcTestCase.php
@@ -25,6 +25,7 @@ use BaserCore\Annotation\UnitTest;
 use BaserCore\Annotation\NoTodo;
 use BaserCore\Annotation\Checked;
 use Cake\Utility\Inflector;
+use ReflectionClass;
 
 /**
  * Class BcTestCase
@@ -143,6 +144,25 @@ class BcTestCase extends TestCase
             ->willReturn($this->returnCallback($callback));
         EventManager::instance()->on($listener);
         return $listener;
+    }
+
+    /**
+     * private・protectedメソッドを実行する
+     * @param object $class 対象クラス
+     * @param string $method 対象メソッド
+     * @param array $args 対象メソッドに必要な引数
+     * @return mixed $value
+     * @checked
+     * @unitTest
+     * @noTodo
+     */
+    protected function execPrivateMethod(object $class, string $method, array $args = [])
+    {
+        $ref = new ReflectionClass($class);
+        $method = $ref->getMethod($method);
+        $method->setAccessible(true);
+        $value= $method->invokeArgs($class, $args);
+        return $value;
     }
 
 }

--- a/plugins/baser-core/src/TestSuite/BcTestCase.php
+++ b/plugins/baser-core/src/TestSuite/BcTestCase.php
@@ -161,7 +161,7 @@ class BcTestCase extends TestCase
         $ref = new ReflectionClass($class);
         $method = $ref->getMethod($method);
         $method->setAccessible(true);
-        $value= $method->invokeArgs($class, $args);
+        $value = $method->invokeArgs($class, $args);
         return $value;
     }
 

--- a/plugins/baser-core/tests/TestCase/Controller/Admin/AnalyseControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/Admin/AnalyseControllerTest.php
@@ -30,7 +30,6 @@ class AnalyseControllerTest extends BcTestCase
     {
         parent::setUp();
         $this->Controller = new AnalyseController($this->getRequest());
-        $this->ref = new ReflectionClass($this->Controller);
     }
 
     /**
@@ -41,18 +40,6 @@ class AnalyseControllerTest extends BcTestCase
     public function tearDown(): void
     {
         parent::tearDown();
-    }
-
-    /**
-     * プライベートメソッドを使用する
-     * @param string $name メソッド名
-     * @return ReflectionMethod $method
-     */
-    private function usePrivateMethod($name)
-    {
-        $method = $this->ref->getMethod($name);
-        $method->setAccessible(true);
-        return $method;
     }
 
     /**
@@ -75,8 +62,7 @@ class AnalyseControllerTest extends BcTestCase
     public function testGetList()
     {
         $path = ROOT . DS . 'plugins' . DS . 'baser-core';
-        $method = $this->usePrivateMethod('getList');
-        $result = $method->invokeArgs($this->Controller, [$path]);
+        $result = $this->execPrivateMethod($this->Controller, 'getList', [$path]);
         $expected = [
             "file" => "content_folders.php",
             "path" => "/plugins/baser-core/config/Schema/content_folders.php",
@@ -96,8 +82,7 @@ class AnalyseControllerTest extends BcTestCase
      */
     public function testGetAnnotations()
     {
-        $method = $this->usePrivateMethod('getAnnotations');
-        $result = $method->invokeArgs($this->Controller, ["\BaserCore\Controller\AnalyseController", "index"]);
+        $result = $this->execPrivateMethod($this->Controller, 'getAnnotations', ["\BaserCore\Controller\AnalyseController", "index"]);
         $expected = [
             "checked" => true,
             "unitTest" => true,
@@ -114,10 +99,9 @@ class AnalyseControllerTest extends BcTestCase
      */
     public function testGetTraitMethod()
     {
-        $method = $this->usePrivateMethod('getTraitMethod');
         // AnalyseControllerTestのIntegrationTestTraitでテスト
         $class = new ReflectionClass($this);
-        $result = $method->invokeArgs($this->Controller, [$class]);
+        $result = $this->execPrivateMethod($this->Controller, 'getTraitMethod', [$class]);
         $expected = "assertResponseOk";
         $this->assertContains($expected, $result);
     }
@@ -132,8 +116,7 @@ class AnalyseControllerTest extends BcTestCase
      */
     public function testPathToClass($path, $expected)
     {
-        $method = $this->usePrivateMethod('pathToClass');
-        $result = $method->invokeArgs($this->Controller, [$path]);
+        $result = $this->execPrivateMethod($this->Controller, 'pathToClass', [$path]);
         $this->assertEquals($result, $expected);
     }
 

--- a/plugins/baser-core/tests/TestCase/Controller/Admin/BcAdminAppControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/Admin/BcAdminAppControllerTest.php
@@ -32,6 +32,7 @@ class BcAdminAppControllerTest extends BcTestCase
     public function setUp(): void
     {
         parent::setUp();
+        $this->template = 'test';
         $this->BcAdminApp = new BcAdminAppController($this->getRequest());
         $this->RequestHandler = $this->BcAdminApp->components()->load('RequestHandler');
     }
@@ -122,18 +123,13 @@ class BcAdminAppControllerTest extends BcTestCase
      */
     public function testSetTitle()
     {
-        $ref = new ReflectionClass($this->BcAdminApp);
-        $method = $ref->getMethod('setTitle');
-        $method->setAccessible(true);
-
-        $template = 'test';
-        $method->invokeArgs($this->BcAdminApp, [$template]);
+        $this->execPrivateMethod($this->BcAdminApp, 'setTitle', [$this->template]);
 
         $viewBuilder = new ReflectionClass($this->BcAdminApp->viewBuilder());
         $vars = $viewBuilder->getProperty('_vars');
         $vars->setAccessible(true);
         $actual = $vars->getValue($this->BcAdminApp->viewBuilder())['title'];
-        $this->assertEquals($template, $actual);
+        $this->assertEquals($this->template, $actual);
     }
 
     /**
@@ -143,18 +139,13 @@ class BcAdminAppControllerTest extends BcTestCase
      */
     public function testSetSearch()
     {
-        $ref = new ReflectionClass($this->BcAdminApp);
-        $method = $ref->getMethod('setSearch');
-        $method->setAccessible(true);
-
-        $template = 'test';
-        $method->invokeArgs($this->BcAdminApp, [$template]);
+        $this->execPrivateMethod($this->BcAdminApp, 'setSearch', [$this->template]);
 
         $viewBuilder = new ReflectionClass($this->BcAdminApp->viewBuilder());
         $vars = $viewBuilder->getProperty('_vars');
         $vars->setAccessible(true);
         $actual = $vars->getValue($this->BcAdminApp->viewBuilder())['search'];
-        $this->assertEquals($template, $actual);
+        $this->assertEquals($this->template, $actual);
     }
 
     /**
@@ -164,18 +155,13 @@ class BcAdminAppControllerTest extends BcTestCase
      */
     public function testSetHelp()
     {
-        $ref = new ReflectionClass($this->BcAdminApp);
-        $method = $ref->getMethod('setHelp');
-        $method->setAccessible(true);
-
-        $template = 'test';
-        $method->invokeArgs($this->BcAdminApp, [$template]);
+        $this->execPrivateMethod($this->BcAdminApp, 'setHelp', [$this->template]);
 
         $viewBuilder = new ReflectionClass($this->BcAdminApp->viewBuilder());
         $vars = $viewBuilder->getProperty('_vars');
         $vars->setAccessible(true);
         $actual = $vars->getValue($this->BcAdminApp->viewBuilder())['help'];
-        $this->assertEquals($template, $actual);
+        $this->assertEquals($this->template, $actual);
     }
 
     /**
@@ -187,19 +173,16 @@ class BcAdminAppControllerTest extends BcTestCase
     {
         Configure::write('BcEnv.host', $referer? parse_url($referer)['host'] : null);
         $_SERVER['HTTP_REFERER'] = $referer;
-        $ref = new ReflectionClass($this->BcAdminApp);
-        $method = $ref->getMethod('_checkReferer');
-        $method->setAccessible(true);
 
         if ($expected === 'error') {
             Configure::write('BcEnv.host', parse_url('http://www.example2.com/')['host']);
             try {
-                $method->invokeArgs($this->BcAdminApp, []);
+                $this->execPrivateMethod($this->BcAdminApp, '_checkReferer');
             } catch (NotFoundException $e) {
                 $this->assertStringContainsString("Not Found", $e->getMessage());
             }
         } else {
-            $result = $method->invokeArgs($this->BcAdminApp, []);
+            $result = $this->execPrivateMethod($this->BcAdminApp, '_checkReferer');
             $this->assertEquals($result, $expected);
         }
     }

--- a/plugins/baser-core/tests/TestCase/Controller/Admin/BcAdminAppControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/Admin/BcAdminAppControllerTest.php
@@ -32,7 +32,6 @@ class BcAdminAppControllerTest extends BcTestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->template = 'test';
         $this->BcAdminApp = new BcAdminAppController($this->getRequest());
         $this->RequestHandler = $this->BcAdminApp->components()->load('RequestHandler');
     }
@@ -123,13 +122,14 @@ class BcAdminAppControllerTest extends BcTestCase
      */
     public function testSetTitle()
     {
-        $this->execPrivateMethod($this->BcAdminApp, 'setTitle', [$this->template]);
+        $template = 'test';
+        $this->execPrivateMethod($this->BcAdminApp, 'setTitle', [$template]);
 
         $viewBuilder = new ReflectionClass($this->BcAdminApp->viewBuilder());
         $vars = $viewBuilder->getProperty('_vars');
         $vars->setAccessible(true);
         $actual = $vars->getValue($this->BcAdminApp->viewBuilder())['title'];
-        $this->assertEquals($this->template, $actual);
+        $this->assertEquals($template, $actual);
     }
 
     /**
@@ -139,13 +139,14 @@ class BcAdminAppControllerTest extends BcTestCase
      */
     public function testSetSearch()
     {
-        $this->execPrivateMethod($this->BcAdminApp, 'setSearch', [$this->template]);
+        $template = 'test';
+        $this->execPrivateMethod($this->BcAdminApp, 'setSearch', [$template]);
 
         $viewBuilder = new ReflectionClass($this->BcAdminApp->viewBuilder());
         $vars = $viewBuilder->getProperty('_vars');
         $vars->setAccessible(true);
         $actual = $vars->getValue($this->BcAdminApp->viewBuilder())['search'];
-        $this->assertEquals($this->template, $actual);
+        $this->assertEquals($template, $actual);
     }
 
     /**
@@ -155,13 +156,14 @@ class BcAdminAppControllerTest extends BcTestCase
      */
     public function testSetHelp()
     {
-        $this->execPrivateMethod($this->BcAdminApp, 'setHelp', [$this->template]);
+        $template = 'test';
+        $this->execPrivateMethod($this->BcAdminApp, 'setHelp', [$template]);
 
         $viewBuilder = new ReflectionClass($this->BcAdminApp->viewBuilder());
         $vars = $viewBuilder->getProperty('_vars');
         $vars->setAccessible(true);
         $actual = $vars->getValue($this->BcAdminApp->viewBuilder())['help'];
-        $this->assertEquals($this->template, $actual);
+        $this->assertEquals($template, $actual);
     }
 
     /**

--- a/plugins/baser-core/tests/TestCase/Model/Entity/PasswordRequestTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Entity/PasswordRequestTest.php
@@ -13,7 +13,6 @@ namespace BaserCore\Test\TestCase\Model\Entity;
 
 use BaserCore\Model\Entity\PasswordRequest;
 use BaserCore\TestSuite\BcTestCase;
-use ReflectionClass;
 
 /**
  * Class PasswordRequest
@@ -69,10 +68,7 @@ class PasswordRequestTest extends BcTestCase
      */
     public function testMakeRequestKey()
     {
-        $ref = new ReflectionClass($this->PasswordRequest);
-        $method = $ref->getMethod('makeRequestKey');
-        $method->setAccessible(true);
-        $requestKey= $method->invokeArgs($this->PasswordRequest, []);
+        $requestKey= $this->execPrivateMethod($this->PasswordRequest, 'makeRequestKey');
         $this->assertEquals('48', strlen($requestKey));
     }
 

--- a/plugins/baser-core/tests/TestCase/TestSuite/BcTestCaseTest.php
+++ b/plugins/baser-core/tests/TestCase/TestSuite/BcTestCaseTest.php
@@ -11,11 +11,11 @@
 
 namespace BaserCore\Test\TestCase\TestSuite;
 
-use Cake\TestSuite\TestCase;
 use BaserCore\TestSuite\BcTestCase;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\Core\Configure;
 use Cake\Routing\Router;
+use BaserCore\Controller\AnalyseController;
 
 /**
  * BaserCore\TestSuite\BcTestCase
@@ -98,4 +98,16 @@ class BcTestCaseTest extends BcTestCase
         $this->assertSession($this->loginAdmin(2), Configure::read('BcPrefixAuth.Admin.sessionKey'));
     }
 
+    /**
+     * 管理画面にログインするのテスト
+     *
+     * @return void
+     */
+    public function testExecPrivateMethod(): void
+    {
+        $sampleClass = new AnalyseController();
+        $samplePrivateMethod = 'pathToClass';
+        $result = $this->execPrivateMethod($sampleClass, $samplePrivateMethod, [ROOT . DS . "plugins"]);
+        $this->assertEquals("", $result);
+    }
 }

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcAdminHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcAdminHelperTest.php
@@ -15,7 +15,6 @@ use BaserCore\TestSuite\BcTestCase;
 use Cake\Core\Configure;
 use BaserCore\View\BcAdminAppView;
 use BaserCore\View\Helper\BcAdminHelper;
-use ReflectionClass;
 
 /**
  * Class BcAdminHelperTest
@@ -188,17 +187,15 @@ class BcAdminHelperTest extends BcTestCase
      */
     public function testGetAdminMenuGroups(): void
     {
-        $ref = new ReflectionClass($this->BcAdmin);
-        $method = $ref->getMethod('getAdminMenuGroups');
-        $method->setAccessible(true);        
-        $adminMenuGroups = $method->invokeArgs($this->BcAdmin, []);
+        $adminMenuGroups = $this->execPrivateMethod($this->BcAdmin, 'getAdminMenuGroups');
         // それぞれのメニューキーを持つか
         $this->assertArrayHasKey('Dashboard', $adminMenuGroups);
         $this->assertArrayHasKey('Users', $adminMenuGroups);
         $this->assertArrayHasKey('Plugin', $adminMenuGroups);
         // adminNavigationがない場合
         Configure::write('BcApp.adminNavigation', null);
-        $this->assertFalse($method->invokeArgs($this->BcAdmin, []));
+        $adminMenuGroups = $this->execPrivateMethod($this->BcAdmin, 'getAdminMenuGroups');
+        $this->assertFalse($adminMenuGroups);
     }
 
     /**
@@ -222,10 +219,7 @@ class BcAdminHelperTest extends BcTestCase
         // $currentSiteIdのテスト
         $this->assertEquals($jsonMenu->currentSiteId, "0");
         // $adminMenuGroupsの取得
-        $ref = new ReflectionClass($this->BcAdmin);
-        $method = $ref->getMethod('getAdminMenuGroups');
-        $method->setAccessible(true);  
-        $adminMenuGroups = $method->invokeArgs($this->BcAdmin, []);
+        $adminMenuGroups = $this->execPrivateMethod($this->BcAdmin, 'getAdminMenuGroups');
         // $menuListに項目が入ってるかテスト
         foreach($jsonMenu->menuList as $menuList) {
             $this->assertContains($menuList->name, array_keys($adminMenuGroups));


### PR DESCRIPTION
よくテストでプライベートメソッドの値を取得する際に使う。
`

　　$ref = new ReflectionClass($this->PasswordRequest);

        $method = $ref->getMethod('method');

        $method->setAccessible(true);

        $return= $method->invokeArgs($this->PasswordRequest, []);

`
をメソッド化しました。

テストも追加してます。