### PR TITLE
$userManage->createが失敗した場合バリデーションが出ないので修正

### DIFF
--- a/plugins/baser-core/src/Controller/Admin/UsersController.php
+++ b/plugins/baser-core/src/Controller/Admin/UsersController.php
@@ -186,7 +186,8 @@ class UsersController extends BcAdminAppController
     public function add(UserManageServiceInterface $userManage)
     {
         if ($this->request->is('post')) {
-            if ($user = $userManage->create($this->request->getData())) {
+            $user = $userManage->create($this->request->getData());
+            if (empty($user->getErrors())) {
                 // EVENT Users.afterAdd
                 $this->getEventManager()->dispatch(new Event('Controller.Users.afterAdd', $this, [
                     'user' => $user
@@ -198,6 +199,7 @@ class UsersController extends BcAdminAppController
         } else {
             $user = $userManage->getNew();
         }
+
         $this->set('user', $user);
     }
 

--- a/plugins/baser-core/src/Service/UsersService.php
+++ b/plugins/baser-core/src/Service/UsersService.php
@@ -110,9 +110,12 @@ class UsersService implements UsersServiceInterface
      */
     public function create(array $postData)
     {
-        $user = $this->Users->newEmptyEntity();
+        $user = $this->getNew();
         $user = $this->Users->patchEntity($user, $postData, ['validate' => 'new']);
-        return $this->Users->save($user);
+        if (!$user->hasErrors()) {
+            $user = $this->Users->save($user);
+        }
+        return $user;
     }
 
     /**

--- a/plugins/baser-core/src/View/Helper/BcAdminUserHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcAdminUserHelper.php
@@ -54,7 +54,7 @@ class BcAdminUserHelper extends Helper
      * @noTodo
      * @unitTest
      */
-    public function isSelfUpdate(int $id)
+    public function isSelfUpdate(?int $id)
     {
         return $this->UserManage->isSelfUpdate($id);
     }
@@ -67,7 +67,7 @@ class BcAdminUserHelper extends Helper
      * @noTodo
      * @unitTest
      */
-    public function isEditable(int $id)
+    public function isEditable(?int $id)
     {
         return $this->UserManage->isEditable($id);
     }


### PR DESCRIPTION
@ryuring 

$userManage->createが失敗した場合falseを返し、$userにEntity情報を持たない。
Entity情報にバリデーションのエラー情報があるので、失敗した場合はnewEntitiesー＞patchEntityの情報を$userとして渡すようにしました。
一度確認お願いします。UserGroupsとPlugin共に同じ問題があるので、こちらOKな形になり次第
テスト書いて、他のものも修正します。