### PR TITLE
管理画面 一覧表示件数の指定方法を調整

### DIFF
--- a/plugins/baser-core/src/Controller/Admin/UsersController.php
+++ b/plugins/baser-core/src/Controller/Admin/UsersController.php
@@ -156,7 +156,7 @@ class UsersController extends BcAdminAppController
     public function index(UserServiceInterface $userService): void
     {
         $this->setViewConditions('User', ['default' => ['query' => [
-            'num' => $userService->getSiteConfig('admin_list_num'),
+            'limit' => $userService->getSiteConfig('admin_list_num'),
             'sort' => 'id',
             'direction' => 'asc',
         ]]]);

--- a/plugins/baser-core/src/Service/UserService.php
+++ b/plugins/baser-core/src/Service/UserService.php
@@ -95,6 +95,11 @@ class UserService implements UserServiceInterface
     public function getIndex(array $queryParams): Query
     {
         $query = $this->Users->find('all')->contain('UserGroups');
+
+        if (!empty($queryParams['limit'])) {
+            $query->limit($queryParams['limit']);
+        }
+
         if (!empty($queryParams['user_group_id'])) {
             $query->matching('UserGroups', function($q) use ($queryParams) {
                 return $q->where(['UserGroups.id' => $queryParams['user_group_id']]);

--- a/plugins/baser-core/src/Service/UserService.php
+++ b/plugins/baser-core/src/Service/UserService.php
@@ -94,11 +94,7 @@ class UserService implements UserServiceInterface
      */
     public function getIndex(array $queryParams): Query
     {
-        $options = [];
-        if (!empty($queryParams['num'])) {
-            $options = ['limit' => $queryParams['num']];
-        }
-        $query = $this->Users->find('all', $options)->contain('UserGroups');
+        $query = $this->Users->find('all')->contain('UserGroups');
         if (!empty($queryParams['user_group_id'])) {
             $query->matching('UserGroups', function($q) use ($queryParams) {
                 return $q->where(['UserGroups.id' => $queryParams['user_group_id']]);

--- a/plugins/baser-core/tests/TestCase/Service/UserServiceTest.php
+++ b/plugins/baser-core/tests/TestCase/Service/UserServiceTest.php
@@ -94,10 +94,6 @@ class UserServiceTest extends BcTestCase
         $users = $this->Users->getIndex($request->getQueryParams());
         $this->assertEquals('baser operator', $users->first()->name);
 
-        $request = $this->getRequest('/?num=1');
-        $users = $this->Users->getIndex($request->getQueryParams());
-        $this->assertEquals(1, $users->all()->count());
-
         $request = $this->getRequest('/?name=baser');
         $users = $this->Users->getIndex($request->getQueryParams());
         $this->assertEquals(3, $users->all()->count());

--- a/plugins/baser-core/tests/TestCase/Service/UserServiceTest.php
+++ b/plugins/baser-core/tests/TestCase/Service/UserServiceTest.php
@@ -33,7 +33,8 @@ class UserServiceTest extends BcTestCase
         'plugin.BaserCore.Users',
         'plugin.BaserCore.UsersUserGroups',
         'plugin.BaserCore.UserGroups',
-        'plugin.BaserCore.LoginStores'
+        'plugin.BaserCore.LoginStores',
+        'plugin.BaserCore.Sites',
     ];
 
     /**
@@ -97,6 +98,10 @@ class UserServiceTest extends BcTestCase
         $request = $this->getRequest('/?name=baser');
         $users = $this->Users->getIndex($request->getQueryParams());
         $this->assertEquals(3, $users->all()->count());
+
+        $request = $this->getRequest('/?limit=1');
+        $users = $this->Users->getIndex($request->getQueryParams());
+        $this->assertEquals(1, $users->all()->count());
     }
 
     /**

--- a/plugins/bc-admin-third/templates/Admin/element/list_num.php
+++ b/plugins/bc-admin-third/templates/Admin/element/list_num.php
@@ -22,13 +22,13 @@ if (empty($nums)) {
 if (!is_array($nums)) {
   $nums = [$nums];
 }
-if (!empty($this->request->getQuery('num'))) {
-  $currentNum = $this->request->getQuery('num');
+if (!empty($this->request->getQuery('limit'))) {
+  $currentNum = $this->request->getQuery('limit');
 }
 $links = [];
 foreach($nums as $num) {
   if ($currentNum != $num) {
-    $links[] = '<span>' . $this->BcBaser->getLink($num, ['?' => array_merge($this->request->getQuery(), ['num' => $num, 'page' => null])]) . '</span>';
+    $links[] = '<span>' . $this->BcBaser->getLink($num, ['?' => array_merge($this->request->getQuery(), ['limit' => $num, 'page' => null])]) . '</span>';
   } else {
     $links[] = '<span class="current">' . $num . '</span>';
   }


### PR DESCRIPTION
管理画面の一覧画面で、下部の表示件数の指定が動作していないため修正しています。
試しにユーザー一覧のみ修正していますので、修正方法に問題ないようでしたら他の箇所も対応します。
ご確認お願いします。