### PR TITLE
システム基本設定のサイドバーのバナー表示設定を反映

### DIFF
--- a/plugins/baser-core/src/View/Helper/BcAdminSiteConfigHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcAdminSiteConfigHelper.php
@@ -12,8 +12,6 @@
 namespace BaserCore\View\Helper;
 
 use BaserCore\Service\SiteConfigService;
-use BaserCore\Service\SiteConfigServiceInterface;
-use BaserCore\Utility\BcContainerTrait;
 use BaserCore\Utility\BcUtil;
 use Cake\Core\Configure;
 use BaserCore\Annotation\UnitTest;
@@ -22,29 +20,9 @@ use BaserCore\Annotation\Checked;
 
 /**
  * BcAdminSiteConfigHelper
- * @property SiteConfigService $SiteConfigService
  */
-class BcAdminSiteConfigHelper extends \Cake\View\Helper
+class BcAdminSiteConfigHelper extends BcSiteConfigHelper
 {
-
-    /**
-     * Trait
-     */
-    use BcContainerTrait;
-
-    /**
-     * initialize
-     * @param array $config
-     * @checked
-     * @noTodo
-     * @unitTest
-     */
-    public function initialize(array $config): void
-    {
-        parent::initialize($config);
-        $this->SiteConfigService = $this->getService(SiteConfigServiceInterface::class);
-    }
-
     /**
      * .env が書き込み可能かどうか
      * @return bool

--- a/plugins/baser-core/src/View/Helper/BcSiteConfigHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcSiteConfigHelper.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <https://basercms.net>
+ * Copyright (c) baserCMS User Community <https://basercms.net/community/>
+ *
+ * @copyright     Copyright (c) baserCMS User Community
+ * @link          https://basercms.net baserCMS Project
+ * @since         5.0.0
+ * @license       http://basercms.net/license/index.html MIT License
+ */
+
+namespace BaserCore\View\Helper;
+
+use BaserCore\Annotation\Checked;
+use BaserCore\Annotation\NoTodo;
+use BaserCore\Annotation\UnitTest;
+use BaserCore\Service\SiteConfigService;
+use BaserCore\Service\SiteConfigServiceInterface;
+use BaserCore\Utility\BcContainerTrait;
+use Cake\View\Helper;
+
+/**
+ * BcSiteConfigHelper
+ * @property SiteConfigService $SiteConfigService
+ */
+class BcSiteConfigHelper extends Helper
+{
+
+    /**
+     * Trait
+     */
+    use BcContainerTrait;
+
+    /**
+     * initialize
+     * @param array $config
+     * @checked
+     * @noTodo
+     * @unitTest
+     */
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+        $this->SiteConfigService = $this->getService(SiteConfigServiceInterface::class);
+    }
+
+    /**
+     * サイト設定を取得
+     * @return string
+     * @checked
+     * @noTodo
+     * @unitTest
+     */
+    public function getValue($fieldName)
+    {
+        return $this->SiteConfigService->getValue($fieldName);
+    }
+
+}

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcSiteConfigHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcSiteConfigHelperTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <https://basercms.net>
+ * Copyright (c) baserCMS User Community <https://basercms.net/community/>
+ *
+ * @copyright     Copyright (c) baserCMS User Community
+ * @link          https://basercms.net baserCMS Project
+ * @since         5.0.0
+ * @license       http://basercms.net/license/index.html MIT License
+ */
+
+namespace BaserCore\Test\TestCase\View\Helper;
+
+use BaserCore\TestSuite\BcTestCase;
+use BaserCore\View\BcAdminAppView;
+use BaserCore\View\Helper\BcSiteConfigHelper;
+
+/**
+ * Class BcSiteConfigHelperTest
+ *
+ * @package BaserCore\Test\TestCase\View\Helper
+ */
+class BcSiteConfigHelperTest extends BcTestCase
+{
+    /**
+     * BcSiteConfigHelper
+     * @var BcSiteConfigHelper
+     */
+    public $BcSiteConfig;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    protected $fixtures = [
+        'plugin.BaserCore.SiteConfigs',
+    ];
+
+    /**
+     * setUp
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->BcSiteConfig = new BcSiteConfigHelper(new BcAdminAppView($this->getRequest('/')));
+    }
+
+    /**
+     * tearDown
+     */
+    public function tearDown(): void
+    {
+        unset($this->BcSiteConfig);
+        parent::tearDown();
+    }
+
+    /**
+     * Test initialize
+     */
+    public function testInitialize()
+    {
+        $this->assertTrue(isset($this->BcSiteConfig->SiteConfigService));
+    }
+
+    /**
+     * Test getValue
+     */
+    public function testGetValue()
+    {
+        $this->assertEquals('3.0.6.1', $this->BcSiteConfig->getValue('version'));
+    }
+}

--- a/plugins/bc-admin-third/templates/Admin/element/sidebar.php
+++ b/plugins/bc-admin-third/templates/Admin/element/sidebar.php
@@ -69,7 +69,7 @@ use BaserCore\View\AppView;
 
   <nav class="bca-nav__main" data-js-container="AdminMenu" hidden></nav>
 
-  <?php if (!empty($this->BcBaser->siteConfig['admin_side_banner'])): ?>
+  <?php if ($this->BcAdminSiteConfig->getValue('admin_side_banner')): ?>
     <div id="BannerArea" class="bca-banners">
       <ul class="bca-banners__ul">
         <li class="bca-banners__li"><a href="https://market.basercms.net/" target="_blank"><img


### PR DESCRIPTION
サイト設定の取得はフロントでも使用する可能性が高いので、BcSiteConfigHelperを作成しました。
既存のBcAdminSiteConfigHelperはBcSiteConfigHelperを継承するよう変更しています。

ご確認お願いします。