### PR TITLE
サイトが一つしかない場合はツールバーのサイト切り替えを表示しない

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/element/toolbar.php
+++ b/plugins/bc-admin-third/templates/Admin/element/toolbar.php
@@ -138,29 +138,29 @@ if ($loginUser) {
     <div id="UserMenu" class="bca-toolbar__users">
       <ul class="clearfix">
         <?php if ($this->BcAuth->isAdminLogin()): ?>
-          <li>
-            <?php $this->BcBaser->link(
-              h($currentSite->display_name) . ' ' .
-              $this->BcBaser->getImg('admin/btn_dropdown.png', ['width' => 8, 'height' => 11, 'class' => 'bc-btn']),
-              'javascript:void(0)', [
-              'class' => 'title',
-              'escapeTitle' => false
-            ]) ?>
-            <?php if ($otherSites): ?>
-              <ul>
-                <?php foreach($otherSites as $key => $value): ?>
-                  <li>
-                    <?php $this->BcBaser->link($value, [
-                      'admin' => true,
-                      'controller' => 'contents',
-                      'action' => 'index',
-                      '?' => ['current_site_id' => $key]
-                    ]) ?>
-                  </li>
-                <?php endforeach ?>
-              </ul>
-            <?php endif ?>
-          </li>
+          <?php if ($otherSites): ?>
+            <li>
+              <?php $this->BcBaser->link(
+                h($currentSite->display_name) . ' ' .
+                $this->BcBaser->getImg('admin/btn_dropdown.png', ['width' => 8, 'height' => 11, 'class' => 'bc-btn']),
+                'javascript:void(0)', [
+                'class' => 'title',
+                'escapeTitle' => false
+              ]) ?>
+                <ul>
+                  <?php foreach($otherSites as $key => $value): ?>
+                    <li>
+                      <?php $this->BcBaser->link($value, [
+                        'admin' => true,
+                        'controller' => 'contents',
+                        'action' => 'index',
+                        '?' => ['current_site_id' => $key]
+                      ]) ?>
+                    </li>
+                  <?php endforeach ?>
+                </ul>
+            </li>
+          <?php endif ?>
           <li>
             <?php $this->BcBaser->link(h($this->BcBaser->getUserName($loginUser)) . ' ' . $this->BcBaser->getImg('admin/btn_dropdown.png', ['width' => 8, 'height' => 11, 'class' => 'bc-btn']), 'javascript:void(0)', ['class' => 'title', 'escapeTitle' => false]) ?>
             <ul>


### PR DESCRIPTION
<img width="375" alt="toolbar" src="https://user-images.githubusercontent.com/30764014/142716804-f9bd8f9e-7322-4aa8-af96-d7c98d27378c.png">

サイトが一つしかない場合は「メインサイト▼」の部分をクリックしても何も起きないため非表示にしました。
ご確認お願いします。