### PR TITLE
ユーザー編集 ダミーフィールドの位置を移動

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/element/Users/form.php
+++ b/plugins/bc-admin-third/templates/Admin/element/Users/form.php
@@ -32,6 +32,12 @@ $userGroups = $this->BcAdminUser->getUserGroupList();
 <div id="UserGroupSetDefaultFavoritesUrl"
      style="display:none"><?php $this->BcBaser->url(['controller' => 'user_groups', 'action' => 'set_default_favorites', @$this->request->getData('UserGroup.id')]) ?></div>
 
+<?php // 自動入力を防止する為のダミーフィールド ?>
+<input type="text" name="dummy-email" style="top:-100px;left:-100px;position:fixed;">
+<?php $this->BcAdminForm->unlockFields('dummy-email') ?>
+<input type="password" name="dummy-pass" autocomplete="off" style="top:-100px;left:-100px;position:fixed;">
+<?php $this->BcAdminForm->unlockFields('dummy-pass') ?>
+
 
 <?php echo $this->BcFormTable->dispatchBefore() ?>
 
@@ -104,8 +110,6 @@ $userGroups = $this->BcAdminUser->getUserGroupList();
       <th class="col-head bca-form-table__label"><?php echo $this->BcAdminForm->label('email', __d('baser', 'Eメール')) ?>
         &nbsp;<span class="bca-label" data-bca-label-type="required"><?php echo __d('baser', '必須') ?></span></th>
       <td class="col-input bca-form-table__input">
-        <input type="text" name="dummy-email" style="top:-100px;left:-100px;position:fixed;">
-        <?php $this->BcAdminForm->unlockFields('dummy-email') ?>
         <?php echo $this->BcAdminForm->control('email', ['type' => 'text', 'size' => 40, 'maxlength' => 255]) ?>
         <i class="bca-icon--question-circle btn help bca-help"></i>
         <div id="helptextEmail" class="helptext">
@@ -125,9 +129,6 @@ $userGroups = $this->BcAdminUser->getUserGroupList();
       <td class="col-input bca-form-table__input">
         <?php if ($this->request->getParam('action') == 'edit'): ?><small>
           [<?php echo __d('baser', 'パスワードは変更する場合のみ入力してください') ?>]</small><br/><?php endif ?>
-        <!-- ↓↓↓自動入力を防止する為のダミーフィールド↓↓↓ -->
-        <input type="password" name="dummy-pass" autocomplete="off" style="top:-100px;left:-100px;position:fixed;">
-        <?php $this->BcAdminForm->unlockFields('dummy-pass') ?>
         <?php echo $this->BcAdminForm->control('password_1', ['type' => 'password', 'size' => 20, 'maxlength' => 255, 'autocomplete' => 'off']) ?>
         <?php echo $this->BcAdminForm->control('password_2', ['type' => 'password', 'size' => 20, 'maxlength' => 255, 'autocomplete' => 'off']) ?>
         <i class="bca-icon--question-circle btn help bca-help"></i>


### PR DESCRIPTION
フォーム中にダミーフィルドが有ると、キーボードの「tab」を押したときにスムーズにフォーカスの移動ができないため移動しました。
ご確認お願いします。