### PR TITLE
ヘッダーリンクの属性を設定できるように調整

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/element/main_body_header_links.php
+++ b/plugins/bc-admin-third/templates/Admin/element/main_body_header_links.php
@@ -32,9 +32,15 @@ if (!isset($mainBodyHeaderLinks)) {
     $confirmMessage = $link['confirm'];
     unset($link['confirm']);
   }
-  $link['class'] = 'bca-btn';
-  $link['data-bca-btn-type'] = $url['action'];
-  $link['data-bca-btn-size'] = 'sm';
+  if (empty($link['class'])) {
+    $link['class'] = 'bca-btn';
+  }
+  if (empty($link['data-bca-btn-type'])) {
+    $link['data-bca-btn-type'] = $url['action'];
+  }
+  if (empty($link['data-bca-btn-size'])) {
+    $link['data-bca-btn-size'] = 'sm';
+  }
   ?>
   <?php $this->BcBaser->link($link['title'], $url, $link, $confirmMessage); ?>
 <?php endforeach; ?>


### PR DESCRIPTION
addAdminMainBodyHeaderLinks からボタンの属性を設定できるように変更しました。

・addAdminMainBodyHeaderLinksが使われている箇所の例
https://github.com/baserproject/ucmitz/blob/dev/plugins/bc-admin-third/templates/Admin/Users/index.php#L19

変更を加えた理由は、現在 data-bca-btn-type はurlのactionから自動的に設定される状態なのですが、action名とは別にボタンの見た目を変更したい場合があるためです。

ご確認お願いします。