### PR TITLE
追加時の必須入力のバリデーションを追加

### DIFF
--- a/plugins/baser-core/src/Model/Table/PasswordRequestsTable.php
+++ b/plugins/baser-core/src/Model/Table/PasswordRequestsTable.php
@@ -75,6 +75,7 @@ class PasswordRequestsTable extends Table
             ->scalar('email')
             ->email('email', true, __d('baser', 'Eメールの形式が不正です。'))
             ->maxLength('email', 255, __d('baser', 'Eメールは255文字以内で入力してください。'))
+            ->requirePresence('email', 'create', __d('baser', 'Eメールを入力してください。'))
             ->notEmptyString('email', __d('baser', 'Eメールを入力してください。'));
         return $validator;
     }

--- a/plugins/baser-core/src/Model/Table/SitesTable.php
+++ b/plugins/baser-core/src/Model/Table/SitesTable.php
@@ -93,6 +93,7 @@ class SitesTable extends AppTable
         $validator
             ->scalar('name')
             ->maxLength('name', 50, __d('baser', '識別名称は50文字以内で入力してください。'))
+            ->requirePresence('name', 'create', __d('baser', '識別名称を入力してください。'))
             ->notEmptyString('name', __d('baser', '識別名称を入力してください。'))
             ->add('name', [
                 'nameUnique' => [
@@ -109,10 +110,12 @@ class SitesTable extends AppTable
         $validator
             ->scalar('display_name')
             ->maxLength('display_name', 50, __d('baser', 'サイト名は50文字以内で入力してください。'))
+            ->requirePresence('display_name', 'create', __d('baser', 'サイト名を入力してください。'))
             ->notEmptyString('display_name', __d('baser', 'サイト名を入力してください。'));
         $validator
             ->scalar('alias')
             ->maxLength('alias', 50, __d('baser', 'エイリアスは50文字以内で入力してください。'))
+            ->requirePresence('alias', 'create', __d('baser', 'エイリアスを入力してください。'))
             ->notEmptyString('alias', __d('baser', 'エイリアスを入力してください。'))
             ->add('alias', [
                 'aliasUnique' => [
@@ -129,6 +132,7 @@ class SitesTable extends AppTable
         $validator
             ->scalar('title')
             ->maxLength('title', 255, __d('baser', 'サイトタイトルは255文字以内で入力してください。'))
+            ->requirePresence('title', 'create', __d('baser', 'サイトタイトルを入力してください。'))
             ->notEmptyString('title', __d('baser', 'サイトタイトルを入力してください。'));
         return $validator;
     }

--- a/plugins/baser-core/src/Model/Table/UserGroupsTable.php
+++ b/plugins/baser-core/src/Model/Table/UserGroupsTable.php
@@ -126,6 +126,7 @@ class UserGroupsTable extends AppTable
         $validator
             ->scalar('name')
             ->maxLength('name', 50, __d('baser', 'ユーザーグループ名は50文字以内で入力してください。'))
+            ->requirePresence('name', 'create', __d('baser', 'ユーザーグループ名を入力してください。'))
             ->notEmptyString('name', __d('baser', 'ユーザーグループ名を入力してください。'))
             ->add('name', [
                 'name_halfText' => [
@@ -143,10 +144,12 @@ class UserGroupsTable extends AppTable
         $validator
             ->scalar('title')
             ->maxLength('title', 50, __d('baser', '表示名は50文字以内で入力してください。'))
+            ->requirePresence('title', 'create', __d('baser', '表示名を入力してください。'))
             ->notEmptyString('title', __d('baser', '表示名を入力してください。'));
 
         $validator
             ->scalar('auth_prefix')
+            ->requirePresence('auth_prefix', 'create', __d('baser', '認証プレフィックスを選択してください。'))
             ->notEmptyString('auth_prefix', __d('baser', '認証プレフィックスを選択してください。'));
 
         $validator

--- a/plugins/baser-core/src/Model/Table/UsersTable.php
+++ b/plugins/baser-core/src/Model/Table/UsersTable.php
@@ -161,6 +161,7 @@ class UsersTable extends Table
         $validator
             ->scalar('name')
             ->maxLength('name', 255, __d('baser', 'アカウント名は255文字以内で入力してください。'))
+            ->requirePresence('name', 'create', __d('baser', 'アカウント名を入力してください。'))
             ->notEmptyString('name', __d('baser', 'アカウント名を入力してください。'))
             ->add('name', [
                 'nameUnique' => [
@@ -177,6 +178,7 @@ class UsersTable extends Table
         $validator
             ->scalar('real_name_1')
             ->maxLength('real_name_1', 50, __d('baser', '名前[姓]は50文字以内で入力してください。'))
+            ->requirePresence('real_name_1', 'create', __d('baser', '名前[姓]を入力してください。'))
             ->notEmptyString('real_name_1', __d('baser', '名前[姓]を入力してください。'));
         $validator
             ->scalar('real_name_2')
@@ -187,6 +189,7 @@ class UsersTable extends Table
             ->maxLength('nickname', 255, __d('baser', 'ニックネームは255文字以内で入力してください。'))
             ->allowEmptyString('nickname');
         $validator
+            ->requirePresence('user_groups', 'create', __d('baser', 'グループを選択してください。'))
             ->add('user_groups', [
                 'userGroupsNotEmptyMultiple' => [
                     'rule' => 'notEmptyMultiple',
@@ -203,6 +206,7 @@ class UsersTable extends Table
                 ]
             ]);
         $validator
+            ->requirePresence('email', 'create', __d('baser', 'Eメールを入力してください。'))
             ->scalar('email')
             ->email('email', true, __d('baser', 'Eメールの形式が不正です。'))
             ->maxLength('email', 255, __d('baser', 'Eメールは255文字以内で入力してください。'))

--- a/plugins/baser-core/src/Service/SiteService.php
+++ b/plugins/baser-core/src/Service/SiteService.php
@@ -56,6 +56,8 @@ class SiteService implements SiteServiceInterface
     {
         return $this->Sites->newEntity([
             'status' => false,
+        ], [
+            'validate' => false,
         ]);
     }
 

--- a/plugins/baser-core/src/Service/UserGroupService.php
+++ b/plugins/baser-core/src/Service/UserGroupService.php
@@ -67,6 +67,8 @@ class UserGroupService implements UserGroupServiceInterface
     {
         return $this->UserGroups->newEntity([
             'auth_prefix' => 'Admin',
+        ], [
+            'validate' => false,
         ]);
     }
 

--- a/plugins/baser-core/src/Service/UserService.php
+++ b/plugins/baser-core/src/Service/UserService.php
@@ -59,8 +59,10 @@ class UserService implements UserServiceInterface
     {
         return $this->Users->newEntity([
             'user_groups' => [
-                '_ids' => [1]
-            ]]);
+                '_ids' => [1],
+            ]], [
+                'validate' => false,
+            ]);
     }
 
     /**

--- a/plugins/baser-core/tests/TestCase/Controller/Admin/UsersControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/Admin/UsersControllerTest.php
@@ -145,6 +145,9 @@ class UsersControllerTest extends BcTestCase
             'real_name_2' => 'Lorem ipsum dolor sit amet',
             'email' => 'test@example.com',
             'nickname' => 'Lorem ipsum dolor sit amet',
+            'user_groups' => [
+                '_ids' => [1]
+            ],
         ];
         $this->post('/baser/admin/baser-core/users/add', $data);
         $this->assertResponseSuccess();
@@ -167,6 +170,9 @@ class UsersControllerTest extends BcTestCase
             'real_name_2' => 'Lorem ipsum dolor sit amet',
             'email' => 'test2@example.com',
             'nickname' => 'Lorem ipsum dolor sit amet',
+            'user_groups' => [
+                '_ids' => [1]
+            ],
         ];
         $this->post('/baser/admin/baser-core/users/add', $data);
         $query = $users->find()->where(['name' => 'etc']);

--- a/plugins/baser-core/tests/TestCase/Controller/Api/UsersControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/Api/UsersControllerTest.php
@@ -120,6 +120,9 @@ class UsersControllerTest extends BcTestCase
             'real_name_2' => 'Lorem ipsum dolor sit amet',
             'email' => 'test@example.com',
             'nickname' => 'Lorem ipsum dolor sit amet',
+            'user_groups' => [
+                '_ids' => [1]
+            ],
         ];
         $this->post('/baser/api/baser-core/users/add.json?token=' . $this->accessToken, $data);
         $this->assertResponseSuccess();

--- a/plugins/baser-core/tests/TestCase/Service/UserServiceTest.php
+++ b/plugins/baser-core/tests/TestCase/Service/UserServiceTest.php
@@ -117,6 +117,8 @@ class UserServiceTest extends BcTestCase
             'user_groups' => [
                 '_ids' => [1]
             ],
+            'email' => 'example@example.com',
+            'real_name_1' => 'test',
             'password_1' => 'aaaaaaaaaaaaaa',
             'password_2' => 'aaaaaaaaaaaaaa'
         ]);


### PR DESCRIPTION
issue https://github.com/baserproject/ucmitz/issues/396

API経由でデータを作成する際に、必須項目がなくてもデータが作成できてしまうため対応しました。

「notEmptyString」で検索した結果のファイルを対象としています。
しかし、以下の2ファイルについてはまだうまく動作確認できなさそうだったので後回しにしています。

- baser-core/src/Model/Table/ContentsTable.php
- baser-core/src/Model/Table/SiteConfigsTable.php

ご確認お願いします。