### PR TITLE
API エラー時のレスポンス調整

### DIFF
--- a/plugins/baser-core/src/Error/BcExceptionRenderer.php
+++ b/plugins/baser-core/src/Error/BcExceptionRenderer.php
@@ -35,7 +35,8 @@ class BcExceptionRenderer extends ExceptionRenderer
     protected function _getController(): Controller
     {
         $controller = parent::_getController();
-        if (!$controller->viewBuilder()->getTheme()) {
+        $request = $controller->getRequest();
+        if (!$request->is('json') && !$controller->viewBuilder()->getTheme()) {
             return new BcErrorController();
         }
         return $controller;

--- a/plugins/baser-core/tests/TestCase/Error/BcExceptionRendererTest.php
+++ b/plugins/baser-core/tests/TestCase/Error/BcExceptionRendererTest.php
@@ -70,6 +70,10 @@ class BcExceptionRendererTest extends BcTestCase
         $this->assertResponseError();
         $this->assertResponseContains('bs-container');
 
+        $this->post('/baser/api/baser-core/users/add.json');
+        $this->assertResponseFailure();
+        $this->assertContentType('application/json');
+
         Configure::write('debug', $debug);
     }
 }


### PR DESCRIPTION
issue: https://github.com/baserproject/ucmitz/issues/417

APIエラー時にJSONではなくHTMLで結果が返却されたので調整しました。
ご確認お願いします。