### PR TITLE
Api SitesController get_selectable_devices_and_lang ユニットテスト実装

### DIFF
--- a/plugins/baser-core/src/Controller/Api/SitesController.php
+++ b/plugins/baser-core/src/Controller/Api/SitesController.php
@@ -142,6 +142,7 @@ class SitesController extends BcApiController
      * @param int $currentSiteId 現在のサイトID
      * @checked
      * @noTodo
+     * @unitTest
      */
     public function get_selectable_devices_and_lang(SiteServiceInterface $sites, $mainSiteId, $currentSiteId = null)
     {

--- a/plugins/baser-core/src/Model/Table/SitesTable.php
+++ b/plugins/baser-core/src/Model/Table/SitesTable.php
@@ -648,7 +648,7 @@ class SitesTable extends AppTable
     }
 
     /**
-     * 選択可能が言語の一覧を取得する
+     * 選択可能な言語の一覧を取得する
      *
      * @param int $mainSiteId メインサイトID
      * @param int $currentSiteId 現在のサイトID

--- a/plugins/baser-core/tests/TestCase/Controller/Api/SitesControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/Api/SitesControllerTest.php
@@ -13,6 +13,7 @@ namespace BaserCore\Test\TestCase\Controller\Api;
 
 use Cake\Core\Configure;
 use Cake\TestSuite\IntegrationTestTrait;
+use ArrayObject;
 
 class SitesControllerTest extends \BaserCore\TestSuite\BcTestCase
 {
@@ -147,6 +148,36 @@ class SitesControllerTest extends \BaserCore\TestSuite\BcTestCase
         $sites = $this->getTableLocator()->get('Sites');
         $query = $sites->find()->where(['id' => 2]);
         $this->assertEquals(0, $query->count());
+    }
+
+    /**
+     * testGet_selectable_devices_and_lang
+     *
+     * @return void
+     */
+    public function testGet_selectable_devices_and_lang(): void
+    {
+        $this->get('/baser/api/baser-core/sites/get_selectable_devices_and_lang/1/4.json?token=' . $this->accessToken);
+        $this->assertResponseSuccess();
+
+        $devicesObj = new ArrayObject(json_decode($this->_response->getBody())->devices);
+        $this->assertEquals(2, $devicesObj->count());
+
+        $langsObj = new ArrayObject(json_decode($this->_response->getBody())->langs);
+        $this->assertEquals(3, $langsObj->count());
+
+        $sites = $this->getTableLocator()->get('Sites');
+        $sites->delete($sites->get(2));
+        $sites->delete($sites->get(3));
+
+        $this->get('/baser/api/baser-core/sites/get_selectable_devices_and_lang/1/4.json?token=' . $this->accessToken);
+        $this->assertResponseSuccess();
+
+        $devicesObj = new ArrayObject(json_decode($this->_response->getBody())->devices);
+        $this->assertEquals(3, $devicesObj->count());
+
+        $langsObj = new ArrayObject(json_decode($this->_response->getBody())->langs);
+        $this->assertEquals(4, $langsObj->count());
     }
 
 }


### PR DESCRIPTION
API の SitesController の get_selectable_devices_and_lang のユニットテストを実装いたしました。
テストの内容は get_selectable_devices_and_lang の内部で使用している getSelectableDevices と getSelectableLangs のユニットテストに合わせております。

https://github.com/baserproject/ucmitz/blob/953c9c76abc6915062d902f57edbc5a27a97bb3d/plugins/baser-core/tests/TestCase/Model/Table/SitesTableTest.php#L239-L247

https://github.com/baserproject/ucmitz/blob/953c9c76abc6915062d902f57edbc5a27a97bb3d/plugins/baser-core/tests/TestCase/Model/Table/SitesTableTest.php#L249-L257

お手隙の際にご確認よろしくお願いいたします！