### PR TITLE
fix #381 メインサイトのサイト名を変更してもツールバーに反映されない

### DIFF
--- a/plugins/baser-core/src/View/Helper/BcAdminSiteHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcAdminSiteHelper.php
@@ -201,7 +201,9 @@ class BcAdminSiteHelper extends Helper
      */
     public function getCurrentSite(): ?Site
     {
-        return $this->_View->getRequest()->getAttribute('currentSite');
+        return $this->SiteService->get(
+            $this->_View->getRequest()->getAttribute('currentSite')->id
+        );
     }
 
     /**

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcAdminSiteHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcAdminSiteHelperTest.php
@@ -13,9 +13,11 @@ namespace BaserCore\Test\TestCase\View\Helper;
 
 use BaserCore\Model\Entity\Site;
 use BaserCore\Service\SiteConfigServiceInterface;
+use BaserCore\Service\SiteService;
 use BaserCore\Utility\BcContainerTrait;
 use BaserCore\View\BcAdminAppView;
 use BaserCore\View\Helper\BcAdminSiteHelper;
+use Cake\Http\ServerRequest;
 
 /**
  * Class BcAdminSiteHelperTest
@@ -115,4 +117,24 @@ class BcAdminSiteHelperTest extends \BaserCore\TestSuite\BcTestCase
         $this->markTestIncomplete('このテストは、まだ実装されていません。');
     }
 
+    /**
+     * Test getCurrentSite
+     */
+    public function testGetCurrentSite()
+    {
+        $request = $this->getRequest('/');
+        $service = new SiteService();
+        $site = $service->create([
+            'main_site_id' => 2,
+            'display_name' => 'beforeChange',
+            'alias' => 'test',
+            'name'  => 'test',
+            'title' => 'test',
+        ]);
+        $request = $request->withAttribute('currentSite', $service->get($site->id));
+        $this->BcAdminSite = new BcAdminSiteHelper(new BcAdminAppView($request));
+        $this->assertEquals('beforeChange', $this->BcAdminSite->getCurrentSite()->display_name);
+        $service->update($site,['display_name' => 'afterChange']);
+        $this->assertEquals('afterChange', $this->BcAdminSite->getCurrentSite()->display_name);
+    }
 }


### PR DESCRIPTION
@humuhimi 
メインサイトのサイト名を変更してもツールバーに反映されない問題を解消しました！

おそらくセッションに保存されているServerRequest オブジェクトに変更前のメインサイト情報が入っており、それが上記の問題を引き起こしていました！

ご確認お願いします！


