### PR TITLE
フォームコントロールの id を自動で付与 fix  #530

### DIFF
--- a/plugins/baser-core/src/View/Helper/BcAdminFormHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcAdminFormHelper.php
@@ -146,7 +146,7 @@ class BcAdminFormHelper extends BcFormHelper
         }
 
         if(!isset($options['id']) || $options['id'] !== false) {
-            $options['id'] = implode(array_map(function($field) { return Inflector::camelize($field); }, explode('.', $name)));
+            $options['id'] = true;
         }
 
         return parent::control($name, $options);

--- a/plugins/baser-core/src/View/Helper/BcAdminFormHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcAdminFormHelper.php
@@ -15,6 +15,7 @@ use BaserCore\Annotation\NoTodo;
 use BaserCore\Annotation\Checked;
 use BaserCore\Annotation\UnitTest;
 use BaserCore\Event\BcEventDispatcherTrait;
+use Cake\Utility\Inflector;
 
 /**
  * Class BcAdminFormHelper
@@ -142,6 +143,10 @@ class BcAdminFormHelper extends BcFormHelper
                 $options['templateVars']['groupClass'] = $groupContainerClass;
             }
 
+        }
+
+        if(!isset($options['id']) || $options['id'] !== false) {
+            $options['id'] = implode(array_map(function($field) { return Inflector::camelize($field); }, explode('.', $name)));
         }
 
         return parent::control($name, $options);


### PR DESCRIPTION
こちらを提供した場合、移行済のJSに影響が出るはずです。

変更理由は下記に記載しています。一緒に検討お願いします。
https://github.com/baserproject/ucmitz/issues/530