### PR TITLE
ContentFoldersTableTest.php testImplementedEvents のテストメソッドを追加 #554

### DIFF
--- a/plugins/baser-core/src/Model/Table/ContentFoldersTable.php
+++ b/plugins/baser-core/src/Model/Table/ContentFoldersTable.php
@@ -70,6 +70,9 @@ class ContentFoldersTable extends AppTable
      * Implemented Events
      *
      * @return array
+     * @checked
+     * @noTodo
+     * @unitTest
      */
     public function implementedEvents(): array
     {

--- a/plugins/baser-core/tests/TestCase/Model/Table/ContentFoldersTableTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/ContentFoldersTableTest.php
@@ -93,6 +93,16 @@ class ContentFoldersTableTest extends BcTestCase
     }
 
     /**
+     * implementedEvents
+     *
+     *  @return void
+     */
+    public function testImplementedEvents()
+    {
+        $this->assertTrue(is_array($this->ContentFolders->implementedEvents()));
+    }
+
+    /**
      * testValidationDefault
      *
      * @return void


### PR DESCRIPTION
テスト追加したので御確認ください

### issue
https://github.com/baserproject/ucmitz/issues/554

### テストコマンド
```
 vendor/bin/phpunit plugins/baser-core/tests/TestCase/Model/Table/ContentFoldersTableTest.php --filter testImplementedEvents
```

### 実行結果
```
root@91d2caa66ee0:/var/www/html# vendor/bin/phpunit plugins/baser-core/tests/TestCase/Model/Table/ContentFoldersTableTest.php --filter testImplementedEvents
Xdebug: [Step Debug] Could not connect to debugging client. Tried: host.docker.internal:9000 (fallback through xdebug.client_host/xdebug.client_port) :-(
PHPUnit 8.5.11 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 1.03 seconds, Memory: 16.00 MB

OK (1 test, 1 assertion)
```