### PR TITLE
BcUtil isOverPostSize ユニットテスト実装

### DIFF
--- a/plugins/baser-core/src/Utility/BcUtil.php
+++ b/plugins/baser-core/src/Utility/BcUtil.php
@@ -939,6 +939,9 @@ class BcUtil
      * 送信されたPOSTがpost_max_sizeを超えているかチェックする
      *
      * @return boolean
+     * @checked
+     * @noTodo
+     * @unitTest
      */
     public static function isOverPostSize()
     {

--- a/plugins/baser-core/tests/TestCase/Utility/BcUtilTest.php
+++ b/plugins/baser-core/tests/TestCase/Utility/BcUtilTest.php
@@ -844,6 +844,36 @@ class BcUtilTest extends BcTestCase
     }
 
     /**
+     * Test isOverPostSize
+     *
+     * @return void
+     * @backupGlobals enabled
+     * @dataProvider isOverPostSizeDataProvider
+     */
+    public function testIsOverPostSize($method, $post, $contentLength, $expect)
+    {
+        $_SERVER['REQUEST_METHOD'] = $method;
+        $_POST = $post;
+        $_SERVER['CONTENT_LENGTH'] = $contentLength;
+
+        $this->assertEquals($expect, BcUtil::isOverPostSize());
+    }
+
+    public function isOverPostSizeDataProvider()
+    {
+        $postMaxSizeMega = preg_replace('/M\z/', '', ini_get('post_max_size'));
+        $postMaxSizeByte = $postMaxSizeMega * 1024 * 1024;
+
+        return [
+            ['POST', [], $postMaxSizeByte + 1, true],
+            ['POST', ['key' => 'value'], 9, false],
+            ['POST', [], 0, false],
+            ['GET', [], null, false]
+
+        ];
+    }
+
+    /**
      * サイトのトップレベルのURLを取得する
      *
      * @return void


### PR DESCRIPTION
BcUtil の isOverPostSize のテストを実装いたしました。
isOverPostSize は受け取った POST のサイズを判別する処理ですが、ユニットテスト内で POST を送信してその POST でテストすることが難しい為、擬似的にグローバル変数を上書きするようにしました。アノテーション `@backupGlobals enabled` でグローバル変数のバックアップはとるようにしています。
https://phpunit.readthedocs.io/ja/latest/annotations.html#backupglobals
お手隙の際にご確認よろしくお願いいたします！