### PR TITLE
LoginStoresTable::addKeyのテストコード実装

### DIFF
--- a/plugins/baser-core/src/Model/Table/LoginStoresTable.php
+++ b/plugins/baser-core/src/Model/Table/LoginStoresTable.php
@@ -16,6 +16,9 @@ use Cake\Utility\Security;
 use Cake\ORM\Table;
 use Cake\ORM\Entity;
 use Cake\ORM\RulesChecker;
+use BaserCore\Annotation\NoTodo;
+use BaserCore\Annotation\Checked;
+use BaserCore\Annotation\UnitTest;
 
 /**
  * Class LoginStoresTable

--- a/plugins/baser-core/src/Model/Table/LoginStoresTable.php
+++ b/plugins/baser-core/src/Model/Table/LoginStoresTable.php
@@ -68,6 +68,9 @@ class LoginStoresTable extends Table
      * @param string $prefix ログイン対象
      * @param int $user_id ユーザID
      * @return EntityInterface
+     * @checked
+     * @noTodo
+     * @unitTest
      */
     public function addKey(string $prefix, int $user_id): EntityInterface
     {

--- a/plugins/baser-core/tests/TestCase/Model/Table/LoginStoresTableTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/LoginStoresTableTest.php
@@ -112,6 +112,7 @@ class LoginStoresTableTest extends BcTestCase
      */
     public function testAddKey()
     {
+        // LoginStoresにキーが追加される
         $beforeCount = $this->LoginStores->find('all')->count();
         $loginStore = $this->LoginStores->addKey('Admin', 1);
         $afterCount = $this->LoginStores->find('all')->count();
@@ -119,8 +120,8 @@ class LoginStoresTableTest extends BcTestCase
 
         // 同一prexi user_idの場合リフレッシュとなり追加されない
         $loginStore2 = $this->LoginStores->addKey('Admin', 1);
-        $loginStore2 = $this->LoginStores->addKey('Admin', 1);
-        $this->assertSame($beforeCount + 1, $afterCount);
+        $afterCount2 = $this->LoginStores->find('all')->count();
+        $this->assertSame($afterCount, $afterCount2);
 
         // キーは変更されている
         $this->assertNotSame($loginStore->store_key, $loginStore2->store_key);


### PR DESCRIPTION
@ryuring このメソッドは既にテストコードが書かれていましたが、アノテーションがついていなかったのと、「コピペしたまま実装忘れてたのかな？」と思しき箇所があったので直しています。ご確認よろしくお願いします！