### PR TITLE
#586 BcPageHelper の一部の関数を BcContentsHelper に移動

### DIFF
--- a/plugins/baser-core/src/View/AppView.php
+++ b/plugins/baser-core/src/View/AppView.php
@@ -16,6 +16,7 @@ use Cake\View\View;
 use BaserCore\Annotation\NoTodo;
 use BaserCore\Annotation\Checked;
 use BaserCore\Annotation\UnitTest;
+use BaserCore\View\Helper\BcContentHelper;
 use BaserCore\View\Helper\BcPageHelper;
 use BaserCore\View\Helper\BcBaserHelper;
 use BaserCore\Event\BcEventDispatcherTrait;
@@ -53,6 +54,7 @@ class AppView extends View
 //        $this->loadHelper('BaserCore.BcArray');
         // <<<
         $this->loadHelper('BaserCore.BcAdmin');
+        $this->loadHelper('BaserCore.BcContents');
         $this->loadHelper('BaserCore.BcPage');
         $this->loadHelper('BaserCore.BcBaser');
         $this->loadHelper('BaserCore.BcToolbar');

--- a/plugins/baser-core/src/View/Helper/BcContentsHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcContentsHelper.php
@@ -707,4 +707,162 @@ class BcContentsHelper extends Helper
         return $this->ContentsService->isAllowPublish($data, $self);
     }
 
+    /**
+     * ページカテゴリ間の次の記事へのリンクを取得する
+     *
+     * MEMO: BcRequest.(agent).aliasは廃止
+     *
+     * @param string $title
+     * @param array $options オプション（初期値 : array()）
+     *    - `class` : CSSのクラス名（初期値 : 'next-link'）
+     *    - `arrow` : 表示文字列（初期値 : ' ≫'）
+     *    - `overCategory` : 固定ページのカテゴリをまたいで次の記事のリンクを取得するかどうか（初期値 : false）
+     *        ※ overCategory が true の場合は、BcPageHelper::contentsNaviAvailable() が false だとしても強制的に出力する
+     *    - `escape` : エスケープするかどうか
+     * @return mixed コンテンツナビが無効かつオプションoverCategoryがtrueでない場合はfalseを返す
+     * @checked
+     * @noTodo
+     * @unitTest
+     */
+    public function getNextLink($title = '', $options = [])
+    {
+        $request = $this->getView()->getRequest();
+        if (empty($request->getParam('Content.id')) || empty($request->getParam('Content.parent_id'))) {
+            return false;
+        }
+        $options = array_merge([
+            'class' => 'next-link',
+            'arrow' => ' ≫',
+            'overCategory' => false,
+            'escape' => true
+        ], $options);
+
+        $arrow = $options['arrow'];
+        $overCategory = $options['overCategory'];
+        unset($options['arrow']);
+        unset($options['overCategory']);
+
+        $neighbors = $this->getPageNeighbors($request->getParam('Content'), $overCategory);
+
+        if (empty($neighbors['next'])) {
+            return false;
+        } else {
+            if (!$title) {
+                $title = $neighbors['next']['title'] . $arrow;
+            }
+            $url = $neighbors['next']['url'];
+            return $this->BcBaser->getLink($title, $url, $options);
+        }
+    }
+
+    /**
+     * ページカテゴリ間の次の記事へのリンクを出力する
+     *
+     * @param string $title
+     * @param array $options オプション（初期値 : array()）
+     *    - `class` : CSSのクラス名（初期値 : 'next-link'）
+     *    - `arrow` : 表示文字列（初期値 : ' ≫'）
+     *    - `overCategory` : 固定ページのカテゴリをまたいで次の記事のリンクを取得するかどうか（初期値 : false）
+     *        ※ overCategory が true の場合は、BcPageHelper::contentsNaviAvailable() が false だとしても強制的に出力する
+     * @return @return void コンテンツナビが無効かつオプションoverCategoryがtrueでない場合はfalseを出力する
+     * @checked
+     * @noTodo
+     * @unitTest
+     */
+    public function nextLink($title = '', $options = [])
+    {
+        echo $this->getNextLink($title, $options);
+    }
+
+    /**
+     * ページカテゴリ間の前の記事へのリンクを取得する
+     *
+     * @param string $title
+     * @param array $options オプション（初期値 : array()）
+     *    - `class` : CSSのクラス名（初期値 : 'prev-link'）
+     *    - `arrow` : 表示文字列（初期値 : ' ≫'）
+     *    - `overCategory` : 固定ページのカテゴリをまたいで次の記事のリンクを取得するかどうか（初期値 : false）
+     *    - `escape` : エスケープするかどうか
+     * @return string|false
+     * @checked
+     * @noTodo
+     * @unitTest
+     */
+    public function getPrevLink($title = '', $options = [])
+    {
+        $request = $this->getView()->getRequest();
+        if (empty($request->getParam('Content.id')) || empty($request->getParam('Content.parent_id'))) {
+            return false;
+        }
+        $options = array_merge([
+            'class' => 'prev-link',
+            'arrow' => '≪ ',
+            'overCategory' => false,
+            'escape' => true
+        ], $options);
+
+        $arrow = $options['arrow'];
+        $overCategory = $options['overCategory'];
+        unset($options['arrow']);
+        unset($options['overCategory']);
+        $content = $request->getParam('Content');
+        $neighbors = $this->getPageNeighbors($content, $overCategory);
+
+        if (empty($neighbors['prev'])) {
+            return false;
+        } else {
+            if (!$title) {
+                $title = $arrow . $neighbors['prev']['title'];
+            }
+            $url = $neighbors['prev']['url'];
+            return $this->BcBaser->getLink($title, $url, $options);
+        }
+    }
+
+    /**
+     * ページカテゴリ間の前の記事へのリンクを出力する
+     *
+     * @param string $title
+     * @param array $options オプション（初期値 : array()）
+     *    - `class` : CSSのクラス名（初期値 : 'prev-link'）
+     *    - `arrow` : 表示文字列（初期値 : ' ≫'）
+     *    - `overCategory` : 固定ページのカテゴリをまたいで次の記事のリンクを取得するかどうか（初期値 : false）
+     *        ※ overCategory が true の場合は、BcPageHelper::contentsNaviAvailable() が false だとしても強制的に出力する
+     * @return void コンテンツナビが無効かつオプションoverCategoryがtrueでない場合はfalseを返す
+     * @checked
+     * @noTodo
+     * @unitTest
+     */
+    public function prevLink($title = '', $options = [])
+    {
+        echo $this->getPrevLink($title, $options);
+    }
+
+    /**
+     * 指定した固定ページデータの次、または、前のデータを取得する
+     *
+     * @param Content $content
+     * @param bool $overCategory カテゴリをまたがるかどうか
+     * @return array 次、または、前の固定ページデータ
+     * @checked
+     * @noTodo
+     * @unitTest
+     */
+    protected function getPageNeighbors($content, $overCategory = false)
+    {
+        $conditions = array_merge($this->ContentsService->getConditionAllowPublish(), [
+            'Contents.type <>' => 'ContentFolder',
+            'Contents.site_id' => $content->site_id
+        ]);
+        if ($overCategory !== true) {
+            $conditions['Contents.parent_id'] = $content->parent_id;
+        }
+        $options = [
+            'field' => 'lft',
+            'value' => $content->lft,
+            'conditions' => $conditions,
+            'order' => ['Contents.lft'],
+        ];
+        return $this->ContentsService->getNeighbors($options);
+    }
 }

--- a/plugins/baser-core/src/View/Helper/BcContentsHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcContentsHelper.php
@@ -708,7 +708,7 @@ class BcContentsHelper extends Helper
     }
 
     /**
-     * ページカテゴリ間の次の記事へのリンクを取得する
+     * フォルダ内の次のコンテンツへのリンクを取得する
      *
      * MEMO: BcRequest.(agent).aliasは廃止
      *
@@ -716,10 +716,10 @@ class BcContentsHelper extends Helper
      * @param array $options オプション（初期値 : array()）
      *    - `class` : CSSのクラス名（初期値 : 'next-link'）
      *    - `arrow` : 表示文字列（初期値 : ' ≫'）
-     *    - `overCategory` : 固定ページのカテゴリをまたいで次の記事のリンクを取得するかどうか（初期値 : false）
-     *        ※ overCategory が true の場合は、BcPageHelper::contentsNaviAvailable() が false だとしても強制的に出力する
+     *    - `overFolder` : フォルダ外も含めるかどうか（初期値 : false）
+     *        ※ overFolder が true の場合は、BcPageHelper::contentsNaviAvailable() が false だとしても強制的に出力する
      *    - `escape` : エスケープするかどうか
-     * @return mixed コンテンツナビが無効かつオプションoverCategoryがtrueでない場合はfalseを返す
+     * @return mixed コンテンツナビが無効かつオプションoverFolderがtrueでない場合はfalseを返す
      * @checked
      * @noTodo
      * @unitTest
@@ -733,16 +733,16 @@ class BcContentsHelper extends Helper
         $options = array_merge([
             'class' => 'next-link',
             'arrow' => ' ≫',
-            'overCategory' => false,
+            'overFolder' => false,
             'escape' => true
         ], $options);
 
         $arrow = $options['arrow'];
-        $overCategory = $options['overCategory'];
+        $overFolder = $options['overFolder'];
         unset($options['arrow']);
-        unset($options['overCategory']);
+        unset($options['overFolder']);
 
-        $neighbors = $this->getPageNeighbors($request->getParam('Content'), $overCategory);
+        $neighbors = $this->getPageNeighbors($request->getParam('Content'), $overFolder);
 
         if (empty($neighbors['next'])) {
             return false;
@@ -756,15 +756,15 @@ class BcContentsHelper extends Helper
     }
 
     /**
-     * ページカテゴリ間の次の記事へのリンクを出力する
+     * フォルダ内の次のコンテンツへのリンクを出力する
      *
      * @param string $title
      * @param array $options オプション（初期値 : array()）
      *    - `class` : CSSのクラス名（初期値 : 'next-link'）
      *    - `arrow` : 表示文字列（初期値 : ' ≫'）
-     *    - `overCategory` : 固定ページのカテゴリをまたいで次の記事のリンクを取得するかどうか（初期値 : false）
-     *        ※ overCategory が true の場合は、BcPageHelper::contentsNaviAvailable() が false だとしても強制的に出力する
-     * @return @return void コンテンツナビが無効かつオプションoverCategoryがtrueでない場合はfalseを出力する
+     *    - `overFolder` : フォルダ外も含めるかどうか（初期値 : false）
+     *        ※ overFolder が true の場合は、BcPageHelper::contentsNaviAvailable() が false だとしても強制的に出力する
+     * @return @return void コンテンツナビが無効かつオプションoverFolderがtrueでない場合はfalseを出力する
      * @checked
      * @noTodo
      * @unitTest
@@ -775,13 +775,13 @@ class BcContentsHelper extends Helper
     }
 
     /**
-     * ページカテゴリ間の前の記事へのリンクを取得する
+     * フォルダ内の前のコンテンツへのリンクを取得する
      *
      * @param string $title
      * @param array $options オプション（初期値 : array()）
      *    - `class` : CSSのクラス名（初期値 : 'prev-link'）
      *    - `arrow` : 表示文字列（初期値 : ' ≫'）
-     *    - `overCategory` : 固定ページのカテゴリをまたいで次の記事のリンクを取得するかどうか（初期値 : false）
+     *    - `overFolder` : フォルダ外も含めるかどうか（初期値 : false）
      *    - `escape` : エスケープするかどうか
      * @return string|false
      * @checked
@@ -797,16 +797,16 @@ class BcContentsHelper extends Helper
         $options = array_merge([
             'class' => 'prev-link',
             'arrow' => '≪ ',
-            'overCategory' => false,
+            'overFolder' => false,
             'escape' => true
         ], $options);
 
         $arrow = $options['arrow'];
-        $overCategory = $options['overCategory'];
+        $overFolder = $options['overFolder'];
         unset($options['arrow']);
-        unset($options['overCategory']);
+        unset($options['overFolder']);
         $content = $request->getParam('Content');
-        $neighbors = $this->getPageNeighbors($content, $overCategory);
+        $neighbors = $this->getPageNeighbors($content, $overFolder);
 
         if (empty($neighbors['prev'])) {
             return false;
@@ -820,15 +820,15 @@ class BcContentsHelper extends Helper
     }
 
     /**
-     * ページカテゴリ間の前の記事へのリンクを出力する
+     * フォルダ内の前のコンテンツへのリンクを出力する
      *
      * @param string $title
      * @param array $options オプション（初期値 : array()）
      *    - `class` : CSSのクラス名（初期値 : 'prev-link'）
      *    - `arrow` : 表示文字列（初期値 : ' ≫'）
-     *    - `overCategory` : 固定ページのカテゴリをまたいで次の記事のリンクを取得するかどうか（初期値 : false）
-     *        ※ overCategory が true の場合は、BcPageHelper::contentsNaviAvailable() が false だとしても強制的に出力する
-     * @return void コンテンツナビが無効かつオプションoverCategoryがtrueでない場合はfalseを返す
+     *    - `overFolder` : フォルダ外も含めるかどうか（初期値 : false）
+     *        ※ overFolder が true の場合は、BcPageHelper::contentsNaviAvailable() が false だとしても強制的に出力する
+     * @return void コンテンツナビが無効かつオプションoverFolderがtrueでない場合はfalseを返す
      * @checked
      * @noTodo
      * @unitTest
@@ -842,19 +842,19 @@ class BcContentsHelper extends Helper
      * 指定した固定ページデータの次、または、前のデータを取得する
      *
      * @param Content $content
-     * @param bool $overCategory カテゴリをまたがるかどうか
+     * @param bool $overFolder フォルダ外も含めるかどうか
      * @return array 次、または、前の固定ページデータ
      * @checked
      * @noTodo
      * @unitTest
      */
-    protected function getPageNeighbors($content, $overCategory = false)
+    protected function getPageNeighbors($content, $overFolder = false)
     {
         $conditions = array_merge($this->ContentsService->getConditionAllowPublish(), [
             'Contents.type <>' => 'ContentFolder',
             'Contents.site_id' => $content->site_id
         ]);
-        if ($overCategory !== true) {
+        if ($overFolder !== true) {
             $conditions['Contents.parent_id'] = $content->parent_id;
         }
         $options = [

--- a/plugins/baser-core/src/View/Helper/BcPageHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcPageHelper.php
@@ -155,36 +155,15 @@ class BcPageHelper extends Helper
      * @checked
      * @noTodo
      * @unitTest
+     * @deprecated BcContentsHelper->getNextLink に移行
      */
     public function getNextLink($title = '', $options = [])
     {
-        $request = $this->getView()->getRequest();
-        if (empty($request->getParam('Content.id')) || empty($request->getParam('Content.parent_id'))) {
-            return false;
+        if (isset($options['overCategory'])) {
+            $options['overFolder'] = $options['overCategory'];
+            unset($options['overCategory']);
         }
-        $options = array_merge([
-            'class' => 'next-link',
-            'arrow' => ' ≫',
-            'overCategory' => false,
-            'escape' => true
-        ], $options);
-
-        $arrow = $options['arrow'];
-        $overCategory = $options['overCategory'];
-        unset($options['arrow']);
-        unset($options['overCategory']);
-
-        $neighbors = $this->getPageNeighbors($request->getParam('Content'), $overCategory);
-
-        if (empty($neighbors['next'])) {
-            return false;
-        } else {
-            if (!$title) {
-                $title = $neighbors['next']['title'] . $arrow;
-            }
-            $url = $neighbors['next']['url'];
-            return $this->BcBaser->getLink($title, $url, $options);
-        }
+        return $this->BcContents->getNextLink($title, $options);
     }
 
     /**
@@ -200,10 +179,15 @@ class BcPageHelper extends Helper
      * @checked
      * @noTodo
      * @unitTest
+     * @deprecated BcContentsHelper->nextLink に移行
      */
     public function nextLink($title = '', $options = [])
     {
-        echo $this->getNextLink($title, $options);
+        if (isset($options['overCategory'])) {
+            $options['overFolder'] = $options['overCategory'];
+            unset($options['overCategory']);
+        }
+        echo $this->BcContents->getNextLink($title, $options);
     }
 
     /**
@@ -219,36 +203,15 @@ class BcPageHelper extends Helper
      * @checked
      * @noTodo
      * @unitTest
+     * @deprecated BcContentsHelper->getPrevLink に移行
      */
     public function getPrevLink($title = '', $options = [])
     {
-        $request = $this->getView()->getRequest();
-        if (empty($request->getParam('Content.id')) || empty($request->getParam('Content.parent_id'))) {
-            return false;
+        if (isset($options['overCategory'])) {
+            $options['overFolder'] = $options['overCategory'];
+            unset($options['overCategory']);
         }
-        $options = array_merge([
-            'class' => 'prev-link',
-            'arrow' => '≪ ',
-            'overCategory' => false,
-            'escape' => true
-        ], $options);
-
-        $arrow = $options['arrow'];
-        $overCategory = $options['overCategory'];
-        unset($options['arrow']);
-        unset($options['overCategory']);
-        $content = $request->getParam('Content');
-        $neighbors = $this->getPageNeighbors($content, $overCategory);
-
-        if (empty($neighbors['prev'])) {
-            return false;
-        } else {
-            if (!$title) {
-                $title = $arrow . $neighbors['prev']['title'];
-            }
-            $url = $neighbors['prev']['url'];
-            return $this->BcBaser->getLink($title, $url, $options);
-        }
+        return $this->BcContents->getPrevLink($title, $options);
     }
 
     /**
@@ -264,37 +227,14 @@ class BcPageHelper extends Helper
      * @checked
      * @noTodo
      * @unitTest
+     * @deprecated BcContentsHelper->prevLink に移行
      */
     public function prevLink($title = '', $options = [])
     {
-        echo $this->getPrevLink($title, $options);
-    }
-
-    /**
-     * 指定した固定ページデータの次、または、前のデータを取得する
-     *
-     * @param Content $content
-     * @param bool $overCategory カテゴリをまたがるかどうか
-     * @return array 次、または、前の固定ページデータ
-     * @checked
-     * @noTodo
-     * @unitTest
-     */
-    protected function getPageNeighbors($content, $overCategory = false)
-    {
-        $conditions = array_merge($this->ContentsService->getConditionAllowPublish(), [
-            'Contents.type <>' => 'ContentFolder',
-            'Contents.site_id' => $content->site_id
-        ]);
-        if ($overCategory !== true) {
-            $conditions['Contents.parent_id'] = $content->parent_id;
+        if (isset($options['overCategory'])) {
+            $options['overFolder'] = $options['overCategory'];
+            unset($options['overCategory']);
         }
-        $options = [
-            'field' => 'lft',
-            'value' => $content->lft,
-            'conditions' => $conditions,
-            'order' => ['Contents.lft'],
-        ];
-        return $this->ContentsService->getNeighbors($options);
+        echo $this->BcContents->getPrevLink($title, $options);
     }
 }

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcContentsHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcContentsHelperTest.php
@@ -21,7 +21,7 @@ use BaserCore\Utility\BcUtil;
 use BaserCore\View\Helper\BcContentsHelper;
 
 /**
- * BcPage helper library.
+ * BcContents helper library.
  *
  * @package Baser.Test.Case
  * @property BcContentsHelper $BcContents
@@ -673,40 +673,40 @@ class BcContentsHelperTest extends BcTestCase
     }
 
     /**
-     * ページカテゴリ間の次の記事へのリンクを取得する
+     * フォルダ内の次のコンテンツへのリンクを取得する
      * @param string $url
      * @param string $title
      * @param array $options オプション（初期値 : array()）
      *    - `class` : CSSのクラス名（初期値 : 'next-link'）
      *    - `arrow` : 表示文字列（初期値 : ' ≫'）
-     *    - `overCategory` : 固定ページのカテゴリをまたいで次の記事のリンクを取得するかどうか（初期値 : false）
+     *    - `overFolder` : フォルダ外も含めるかどうか（初期値 : false）
      * @param string $expected
      *
      * @dataProvider getNextLinkDataProvider
      */
     public function testGetNextLink($url, $title, $options, $expected)
     {
-        $this->BcPage->getView()->setRequest($this->getRequest($url));
-        $result = $this->BcPage->getNextLink($title, $options);
+        $this->BcContents->getView()->setRequest($this->getRequest($url));
+        $result = $this->BcContents->getNextLink($title, $options);
         $this->assertEquals($expected, $result);
     }
 
     public function getNextLinkDataProvider()
     {
         return [
-            ['/company', '', ['overCategory' => false], false], // PC
-            ['/company', '次のページへ', ['overCategory' => false], false], // PC
-            ['/about', '', ['overCategory' => true], '<a href="/service/service1" class="next-link">サービス１ ≫</a>'], // PC
-            ['/about', '次のページへ', ['overCategory' => true], '<a href="/service/service1" class="next-link">次のページへ</a>'], // PC
-            ['/en/サイトID3の固定ページ2', '', ['overCategory' => false], '<a href="/en/サイトID3の固定ページ3" class="next-link">サイトID3の固定ページ3 ≫</a>'], // smartphone
-            // ['/s/about', '', ['overCategory' => false], '<a href="/s/icons" class="next-link">アイコンの使い方 ≫</a>'], // smartphone
-            // ['/s/about', '次のページへ', ['overCategory' => false], '<a href="/s/icons" class="next-link">次のページへ</a>'], // smartphone
-            // ['/s/sitemap', '', ['overCategory' => true], '<a href="/s/contact/" class="next-link">お問い合わせ ≫</a>'], // smartphone
-            // ['/s/sitemap', '次のページへ', ['overCategory' => true], '<a href="/s/contact/" class="next-link">次のページへ</a>'], // smartphone
+            ['/company', '', ['overFolder' => false], false], // PC
+            ['/company', '次のページへ', ['overFolder' => false], false], // PC
+            ['/about', '', ['overFolder' => true], '<a href="/service/service1" class="next-link">サービス１ ≫</a>'], // PC
+            ['/about', '次のページへ', ['overFolder' => true], '<a href="/service/service1" class="next-link">次のページへ</a>'], // PC
+            ['/en/サイトID3の固定ページ2', '', ['overFolder' => false], '<a href="/en/サイトID3の固定ページ3" class="next-link">サイトID3の固定ページ3 ≫</a>'], // smartphone
+            // ['/s/about', '', ['overFolder' => false], '<a href="/s/icons" class="next-link">アイコンの使い方 ≫</a>'], // smartphone
+            // ['/s/about', '次のページへ', ['overFolder' => false], '<a href="/s/icons" class="next-link">次のページへ</a>'], // smartphone
+            // ['/s/sitemap', '', ['overFolder' => true], '<a href="/s/contact/" class="next-link">お問い合わせ ≫</a>'], // smartphone
+            // ['/s/sitemap', '次のページへ', ['overFolder' => true], '<a href="/s/contact/" class="next-link">次のページへ</a>'], // smartphone
         ];
     }
     /**
-     * ページカテゴリ間の次の記事へのリンクを出力する
+     * フォルダ内の次のコンテンツへのリンクを出力する
      *
      *    public function testNextLink($url, $title, $options, $expected) { }
      */
@@ -717,44 +717,44 @@ class BcContentsHelperTest extends BcTestCase
       */
     public function testNextLink()
     {
-        $this->BcPage->getView()->setRequest($this->getRequest('/about'));
+        $this->BcContents->getView()->setRequest($this->getRequest('/about'));
         ob_start();
-        $this->BcPage->nextLink('次のページへ', ['overCategory' => false]);
+        $this->BcContents->nextLink('次のページへ', ['overFolder' => false]);
         $result = ob_get_clean();
         $this->assertMatchesRegularExpression('/<a href="\/contact\/" class="next-link">/', $result);
     }
 
     /**
-     * ページカテゴリ間の前の記事へのリンクを取得する
+     * フォルダ内の前のコンテンツへのリンクを取得する
      * @param string $url
      * @param string $title
      * @param array $options オプション（初期値 : array()）
      *    - `class` : CSSのクラス名（初期値 : 'next-link'）
      *    - `arrow` : 表示文字列（初期値 : ' ≫'）
-     *    - `overCategory` : 固定ページのカテゴリをまたいで次の記事のリンクを取得するかどうか（初期値 : false）
+     *    - `overFolder` : フォルダ外も含めるかどうか（初期値 : false）
      * @param string $expected
      *
      * @dataProvider getPrevLinkDataProvider
      */
     public function testGetPrevLink($url, $title, $options, $expected)
     {
-        $this->BcPage->getView()->setRequest($this->getRequest($url));
-        $result = $this->BcPage->getPrevLink($title, $options);
+        $this->BcContents->getView()->setRequest($this->getRequest($url));
+        $result = $this->BcContents->getPrevLink($title, $options);
         $this->assertEquals($expected, $result);
     }
 
     public function getPrevLinkDataProvider()
     {
         return [
-            ['/company', '', ['overCategory' => false], false], // PC
-            ['/company', '前のページへ', ['overCategory' => false], false], // PC
-            ['/about', '', ['overCategory' => true], '<a href="/news/" class="prev-link">≪ NEWS(※関連Fixture未完了)</a>'], // PC
-            ['/about', '前のページへ', ['overCategory' => true], '<a href="/news/" class="prev-link">前のページへ</a>'], // PC
-            ['/en/サイトID3の固定ページ2', '', ['overCategory' => false], '<a href="/en/サイトID3の固定ページ" class="prev-link">≪ サイトID3の固定ページ</a>'], // smartphone
-            // ['/s/about', '', ['overCategory' => false], '<a href="/s/" class="prev-link">≪ トップページ</a>'], // smartphone
-            // ['/s/about', '前のページへ', ['overCategory' => false], '<a href="/s/" class="prev-link">前のページへ</a>'], // smartphone
-            // ['/s/sitemap', '', ['overCategory' => true], '<a href="/s/icons" class="prev-link">≪ アイコンの使い方</a>'], // smartphone
-            // ['/s/sitemap', '前のページへ', ['overCategory' => true], '<a href="/s/icons" class="prev-link">前のページへ</a>'], // smartphone
+            ['/company', '', ['overFolder' => false], false], // PC
+            ['/company', '前のページへ', ['overFolder' => false], false], // PC
+            ['/about', '', ['overFolder' => true], '<a href="/news/" class="prev-link">≪ NEWS(※関連Fixture未完了)</a>'], // PC
+            ['/about', '前のページへ', ['overFolder' => true], '<a href="/news/" class="prev-link">前のページへ</a>'], // PC
+            ['/en/サイトID3の固定ページ2', '', ['overFolder' => false], '<a href="/en/サイトID3の固定ページ" class="prev-link">≪ サイトID3の固定ページ</a>'], // smartphone
+            // ['/s/about', '', ['overFolder' => false], '<a href="/s/" class="prev-link">≪ トップページ</a>'], // smartphone
+            // ['/s/about', '前のページへ', ['overFolder' => false], '<a href="/s/" class="prev-link">前のページへ</a>'], // smartphone
+            // ['/s/sitemap', '', ['overFolder' => true], '<a href="/s/icons" class="prev-link">≪ アイコンの使い方</a>'], // smartphone
+            // ['/s/sitemap', '前のページへ', ['overFolder' => true], '<a href="/s/icons" class="prev-link">前のページへ</a>'], // smartphone
         ];
     }
 
@@ -765,9 +765,9 @@ class BcContentsHelperTest extends BcTestCase
      */
     public function testPrevLink()
     {
-        $this->BcPage->getView()->setRequest($this->getRequest('/about'));
+        $this->BcContents->getView()->setRequest($this->getRequest('/about'));
         ob_start();
-        $this->BcPage->prevLink('前のページへ', ['overCategory' => false]);
+        $this->BcContents->prevLink('前のページへ', ['overFolder' => false]);
         $result = ob_get_clean();
         $this->assertMatchesRegularExpression('/<a href="\/news\/" class="prev-link">/', $result);
     }
@@ -778,10 +778,10 @@ class BcContentsHelperTest extends BcTestCase
      * @return void
      * @dataProvider getPageNeighborsDataProvider
      */
-    public function testGetPageNeighbors($overCategory, $title)
+    public function testGetPageNeighbors($overFolder, $title)
     {
-        $content = $this->BcPage->ContentsService->getIndex(['name' => 'about'])->first();
-        $neighbors = $this->execPrivateMethod($this->BcPage, 'getPageNeighbors', [$content, $overCategory]);
+        $content = $this->BcContents->ContentsService->getIndex(['name' => 'about'])->first();
+        $neighbors = $this->execPrivateMethod($this->BcContents, 'getPageNeighbors', [$content, $overFolder]);
         $this->assertEquals($neighbors['prev']['title'], $title['prev']);
         $this->assertEquals($neighbors['next']['title'], $title['next']);
     }

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcContentsHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcContentsHelperTest.php
@@ -672,4 +672,125 @@ class BcContentsHelperTest extends BcTestCase
         ];
     }
 
+    /**
+     * ページカテゴリ間の次の記事へのリンクを取得する
+     * @param string $url
+     * @param string $title
+     * @param array $options オプション（初期値 : array()）
+     *    - `class` : CSSのクラス名（初期値 : 'next-link'）
+     *    - `arrow` : 表示文字列（初期値 : ' ≫'）
+     *    - `overCategory` : 固定ページのカテゴリをまたいで次の記事のリンクを取得するかどうか（初期値 : false）
+     * @param string $expected
+     *
+     * @dataProvider getNextLinkDataProvider
+     */
+    public function testGetNextLink($url, $title, $options, $expected)
+    {
+        $this->BcPage->getView()->setRequest($this->getRequest($url));
+        $result = $this->BcPage->getNextLink($title, $options);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function getNextLinkDataProvider()
+    {
+        return [
+            ['/company', '', ['overCategory' => false], false], // PC
+            ['/company', '次のページへ', ['overCategory' => false], false], // PC
+            ['/about', '', ['overCategory' => true], '<a href="/service/service1" class="next-link">サービス１ ≫</a>'], // PC
+            ['/about', '次のページへ', ['overCategory' => true], '<a href="/service/service1" class="next-link">次のページへ</a>'], // PC
+            ['/en/サイトID3の固定ページ2', '', ['overCategory' => false], '<a href="/en/サイトID3の固定ページ3" class="next-link">サイトID3の固定ページ3 ≫</a>'], // smartphone
+            // ['/s/about', '', ['overCategory' => false], '<a href="/s/icons" class="next-link">アイコンの使い方 ≫</a>'], // smartphone
+            // ['/s/about', '次のページへ', ['overCategory' => false], '<a href="/s/icons" class="next-link">次のページへ</a>'], // smartphone
+            // ['/s/sitemap', '', ['overCategory' => true], '<a href="/s/contact/" class="next-link">お問い合わせ ≫</a>'], // smartphone
+            // ['/s/sitemap', '次のページへ', ['overCategory' => true], '<a href="/s/contact/" class="next-link">次のページへ</a>'], // smartphone
+        ];
+    }
+    /**
+     * ページカテゴリ間の次の記事へのリンクを出力する
+     *
+     *    public function testNextLink($url, $title, $options, $expected) { }
+     */
+    /**
+      * testNextLink
+      *
+      * @return void
+      */
+    public function testNextLink()
+    {
+        $this->BcPage->getView()->setRequest($this->getRequest('/about'));
+        ob_start();
+        $this->BcPage->nextLink('次のページへ', ['overCategory' => false]);
+        $result = ob_get_clean();
+        $this->assertMatchesRegularExpression('/<a href="\/contact\/" class="next-link">/', $result);
+    }
+
+    /**
+     * ページカテゴリ間の前の記事へのリンクを取得する
+     * @param string $url
+     * @param string $title
+     * @param array $options オプション（初期値 : array()）
+     *    - `class` : CSSのクラス名（初期値 : 'next-link'）
+     *    - `arrow` : 表示文字列（初期値 : ' ≫'）
+     *    - `overCategory` : 固定ページのカテゴリをまたいで次の記事のリンクを取得するかどうか（初期値 : false）
+     * @param string $expected
+     *
+     * @dataProvider getPrevLinkDataProvider
+     */
+    public function testGetPrevLink($url, $title, $options, $expected)
+    {
+        $this->BcPage->getView()->setRequest($this->getRequest($url));
+        $result = $this->BcPage->getPrevLink($title, $options);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function getPrevLinkDataProvider()
+    {
+        return [
+            ['/company', '', ['overCategory' => false], false], // PC
+            ['/company', '前のページへ', ['overCategory' => false], false], // PC
+            ['/about', '', ['overCategory' => true], '<a href="/news/" class="prev-link">≪ NEWS(※関連Fixture未完了)</a>'], // PC
+            ['/about', '前のページへ', ['overCategory' => true], '<a href="/news/" class="prev-link">前のページへ</a>'], // PC
+            ['/en/サイトID3の固定ページ2', '', ['overCategory' => false], '<a href="/en/サイトID3の固定ページ" class="prev-link">≪ サイトID3の固定ページ</a>'], // smartphone
+            // ['/s/about', '', ['overCategory' => false], '<a href="/s/" class="prev-link">≪ トップページ</a>'], // smartphone
+            // ['/s/about', '前のページへ', ['overCategory' => false], '<a href="/s/" class="prev-link">前のページへ</a>'], // smartphone
+            // ['/s/sitemap', '', ['overCategory' => true], '<a href="/s/icons" class="prev-link">≪ アイコンの使い方</a>'], // smartphone
+            // ['/s/sitemap', '前のページへ', ['overCategory' => true], '<a href="/s/icons" class="prev-link">前のページへ</a>'], // smartphone
+        ];
+    }
+
+    /**
+     * testPrevLink
+     *
+     * @return void
+     */
+    public function testPrevLink()
+    {
+        $this->BcPage->getView()->setRequest($this->getRequest('/about'));
+        ob_start();
+        $this->BcPage->prevLink('前のページへ', ['overCategory' => false]);
+        $result = ob_get_clean();
+        $this->assertMatchesRegularExpression('/<a href="\/news\/" class="prev-link">/', $result);
+    }
+
+    /**
+     * testGetPageByNextOrPrev
+     *
+     * @return void
+     * @dataProvider getPageNeighborsDataProvider
+     */
+    public function testGetPageNeighbors($overCategory, $title)
+    {
+        $content = $this->BcPage->ContentsService->getIndex(['name' => 'about'])->first();
+        $neighbors = $this->execPrivateMethod($this->BcPage, 'getPageNeighbors', [$content, $overCategory]);
+        $this->assertEquals($neighbors['prev']['title'], $title['prev']);
+        $this->assertEquals($neighbors['next']['title'], $title['next']);
+    }
+
+    public function getPageNeighborsDataProvider()
+    {
+        return [
+            [false, ['prev' => "NEWS(※関連Fixture未完了)", 'next' => "お問い合わせ(※関連Fixture未完了)"]],
+            [true, ['prev' => "NEWS(※関連Fixture未完了)", 'next' => "サービス１"]],
+        ];
+    }
 }

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcPageHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcPageHelperTest.php
@@ -265,12 +265,6 @@ class BcPageHelperTest extends BcTestCase
     }
 
     /**
-     * ページカテゴリ間の前の記事へのリンクを出力する
-     *
-     * public function testPrevLink($url, $title, $options, $expected) { }
-     */
-
-    /**
      * ページリストを取得する
      *
      * @dataProvider getPageListDataProvider
@@ -297,26 +291,4 @@ class BcPageHelperTest extends BcTestCase
         $this->markTestIncomplete('このテストは、まだ実装されていません。');
     }
 
-
-    /**
-     * testGetPageByNextOrPrev
-     *
-     * @return void
-     * @dataProvider getPageNeighborsDataProvider
-     */
-    public function testGetPageNeighbors($overCategory, $title)
-    {
-        $content = $this->BcPage->ContentsService->getIndex(['name' => 'about'])->first();
-        $neighbors = $this->execPrivateMethod($this->BcPage, 'getPageNeighbors', [$content, $overCategory]);
-        $this->assertEquals($neighbors['prev']['title'], $title['prev']);
-        $this->assertEquals($neighbors['next']['title'], $title['next']);
-    }
-
-    public function getPageNeighborsDataProvider()
-    {
-        return [
-            [false, ['prev' => "NEWS(※関連Fixture未完了)", 'next' => "お問い合わせ(※関連Fixture未完了)"]],
-            [true, ['prev' => "NEWS(※関連Fixture未完了)", 'next' => "サービス１"]],
-        ];
-    }
 }


### PR DESCRIPTION
以下のissueに対応しました。
https://github.com/baserproject/ucmitz/issues/586

BcPageの関数の `@deprecated` の廃止予定のバージョンは記載していないので、指定頂ければと思います。

コメントの変更に合わせて、 `overCategory` というオプションを `overFolder` に変更しています。
後方互換を考慮とのことだったので、BcPageの方を呼び出した際は `overCategory` でも動作するようにしています。

ご確認よろしくお願いします。
