### PR TITLE
LoginStoresTableTest::BuildRules

### DIFF
--- a/plugins/baser-core/src/Model/Table/LoginStoresTable.php
+++ b/plugins/baser-core/src/Model/Table/LoginStoresTable.php
@@ -61,6 +61,9 @@ class LoginStoresTable extends Table
      * buildRules
      * @param RulesChecker $rules
      * @return RulesChecker
+     * @checked
+     * @noTodo
+     * @unitTest
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {


### PR DESCRIPTION
@ryuring 
テストコードはすでに実装されていたのですが、コード内で明示的にBuildRulesメソッドが使われていなかったので念の為その旨をここにメモしておきます。