### PR TITLE
CopyFailedExceptionTestのtestSetErrorsとtestGetErrorsを統合

### DIFF
--- a/plugins/baser-core/src/Model/Table/Exception/CopyFailedException.php
+++ b/plugins/baser-core/src/Model/Table/Exception/CopyFailedException.php
@@ -48,6 +48,9 @@ class CopyFailedException extends Exception
      * getErrors
      *
      * @return void
+     * @checked
+     * @noTodo
+     * @unitTest
      */
     public function getErrors()
     {

--- a/plugins/baser-core/tests/TestCase/Model/Table/Exception/CopyFailedExceptionTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/Exception/CopyFailedExceptionTest.php
@@ -60,9 +60,9 @@ class CopyFailedExceptionTest extends BcTestCase
     }
 
     /**
-     * Test setErrors
+     * Test setErrors and getErrors
      */
-    public function testSetErrors()
+    public function testSetErrorsAndGetErrors()
     {
         $this->CopyFailedException->setErrors(['testerror1', 'testerror2']);
         $errors = $this->CopyFailedException->getErrors();


### PR DESCRIPTION
@ryuring 
testSetErrorsとtestGetErrorsを統合したので、CopyFailedExceptionTest::getErrorsのプルリクは取り下げて、改めてプルリクをお送りします！