### PR TITLE
Login stores table test.refresh

### DIFF
--- a/plugins/baser-core/src/Model/Table/LoginStoresTable.php
+++ b/plugins/baser-core/src/Model/Table/LoginStoresTable.php
@@ -153,6 +153,9 @@ class LoginStoresTable extends Table
      * @param string $prefix ログイン対象
      * @param int $user_id ユーザID
      * @return EntityInterface|null
+     * @checked
+     * @noTodo
+     * @unitTest
      */
     public function refresh($prefix, $user_id): EntityInterface
     {

--- a/plugins/baser-core/src/Model/Table/LoginStoresTable.php
+++ b/plugins/baser-core/src/Model/Table/LoginStoresTable.php
@@ -153,9 +153,6 @@ class LoginStoresTable extends Table
      * @param string $prefix ログイン対象
      * @param int $user_id ユーザID
      * @return EntityInterface|null
-     * @checked
-     * @noTodo
-     * @unitTest
      */
     public function refresh($prefix, $user_id): EntityInterface
     {

--- a/plugins/baser-core/tests/TestCase/Model/Table/LoginStoresTableTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/LoginStoresTableTest.php
@@ -14,6 +14,7 @@ namespace BaserCore\Test\TestCase\Model\Table;
 use BaserCore\Model\Table\LoginStoresTable;
 use BaserCore\TestSuite\BcTestCase;
 use Cake\TestSuite\IntegrationTestTrait;
+use Exception;
 
 /**
  * BaserCore\Model\Table\LoginStoresTable Test Case
@@ -209,13 +210,9 @@ class LoginStoresTableTest extends BcTestCase
             ]
         ));
 
-        $errorMesage = "";
-        try {
-            $loginStore4 = $this->LoginStores->refresh('Admin', 0);
-        } catch (\Exception $e) {
-            $errorMesage = $e->getMessage();
-        }
-        $this->assertSame($errorMesage, "更新データが見つかりませんでした");
+        $this->expectException(Exception::class);
+        $this->LoginStores->refresh('Admin', 0);
+
     }
 
 }

--- a/plugins/baser-core/tests/TestCase/Model/Table/LoginStoresTableTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/LoginStoresTableTest.php
@@ -208,6 +208,14 @@ class LoginStoresTableTest extends BcTestCase
                 $loginStore2->store_key
             ]
         ));
+
+        $errorMesage = "";
+        try {
+            $loginStore4 = $this->LoginStores->refresh('Admin', 0);
+        } catch (\Exception $e) {
+            $errorMesage = $e->getMessage();
+        }
+        $this->assertSame($errorMesage, "更新データが見つかりませんでした");
     }
 
 }

--- a/plugins/baser-core/tests/TestCase/Model/Table/LoginStoresTableTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/LoginStoresTableTest.php
@@ -208,15 +208,6 @@ class LoginStoresTableTest extends BcTestCase
                 $loginStore2->store_key
             ]
         ));
-
-        // Exeptionが発生
-        $errorMesage = "";
-        try {
-            $loginStore4 = $this->LoginStores->refresh('Admin', 0);
-        } catch (\Exception $e) {
-            $errorMesage = $e->getMessage();
-        }
-        $this->assertSame($errorMesage, "更新データが見つかりませんでした");
     }
 
 }

--- a/plugins/baser-core/tests/TestCase/Model/Table/LoginStoresTableTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/LoginStoresTableTest.php
@@ -208,6 +208,15 @@ class LoginStoresTableTest extends BcTestCase
                 $loginStore2->store_key
             ]
         ));
+
+        // Exeptionが発生
+        $errorMesage = "";
+        try {
+            $loginStore4 = $this->LoginStores->refresh('Admin', 0);
+        } catch (\Exception $e) {
+            $errorMesage = $e->getMessage();
+        }
+        $this->assertSame($errorMesage, "更新データが見つかりませんでした");
     }
 
 }


### PR DESCRIPTION
@ryuring 
例外発生時のメッセージが一言一句合ってないとテストが通らない仕様にしているので、以前に特定の配列を返すだけのメソッドで「少しコードを変更しただけで引っかかってしまうテストコードは良くない」とご指摘頂いたので少し迷いましたが、既存のtestAddKeyメソッドを参考にしてこのように書きました。