### PR TITLE
#603 固定ページ 公開期間を空にできない

### DIFF
--- a/plugins/baser-core/src/Model/Table/ContentsTable.php
+++ b/plugins/baser-core/src/Model/Table/ContentsTable.php
@@ -104,7 +104,7 @@ class ContentsTable extends AppTable
 
     /**
      * Implemented Events
-     * 
+     *
      * @return array
      * @checked
      * @noTodo
@@ -324,10 +324,10 @@ class ContentsTable extends AppTable
                 if ($user) $content['author_id'] = $user['id'];
             }
         } else {
-            if (isset($content['self_publish_begin'])) {
+            if (!empty($content['self_publish_begin'])) {
                 $content['self_publish_begin'] = new FrozenTime($content['self_publish_begin']);
             }
-            if (isset($content['self_publish_end'])) {
+            if (!empty($content['self_publish_end'])) {
                 $content['self_publish_end'] = new FrozenTime($content['self_publish_end']);
             }
             if (empty($content['modified_date'])) {
@@ -335,11 +335,8 @@ class ContentsTable extends AppTable
             } else {
                 $content['modified_date'] = new FrozenTime($content['modified_date']);
             }
-            if (isset($content['created_date'])) {
+            if (!empty($content['created_date'])) {
                 $content['created_date'] = new FrozenTime($content['created_date']);
-            }
-            if (isset($content['name'])) {
-                $content['name'] = $content['name'];
             }
         }
         // name の 重複チェック＆リネーム


### PR DESCRIPTION
issue: https://github.com/baserproject/ucmitz/issues/603

固定ページ編集にて日時を空にできない問題を修正しました。
原因はFrozenTimeに空の値を渡すと現在日時が設定されるためでした。

なお、今回のコミットを適用しても作成日時を空にできない問題は解決しないのですが、作成日時に関しては本来必須入力のバリデーションエラーが出るはずなのに、エラーが表示されないことが問題でした。
この件については、以下のプルリクマージ後に解消される見込みです。
https://github.com/baserproject/ucmitz/pull/589

また、以下の箇所を削除しているのは今回の修正とは関係ないのですが、不要な行のため削除しています。

```
if (isset($content['name'])) {
    $content['name'] = $content['name'];
}
```

ご確認よろしくお願いします。