### PR TITLE
fix #622 固定ページで公開期間を変更しようとするとエラー

### DIFF
--- a/plugins/baser-core/src/View/Helper/BcFormHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcFormHelper.php
@@ -296,6 +296,7 @@ SCRIPT_END;
             $timeTag = $this->BcHtml->tag($tag, $timeTag, $timeDivOptions);
         }
         $hiddenTag = $this->hidden($fieldName, ['value' => $value, 'id' => $options['id']]);
+        $this->unlockField($fieldName);
         $script = <<< SCRIPT_END
 <script>
 $(function(){

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcAdminFormHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcAdminFormHelperTest.php
@@ -48,8 +48,12 @@ class BcAdminFormHelperTest extends BcTestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->BcAdminForm = new BcAdminFormHelper(new BcAdminAppView($this->getRequest()));
-        $this->BcForm = new BcFormHelper(new BcAdminAppView($this->getRequest()));
+        $View = new BcAdminAppView($this->getRequest());
+        $View->setRequest($View->getRequest()->withAttribute('formTokenData', [
+            'unlockedFields' => [],
+        ]));
+        $this->BcAdminForm = new BcAdminFormHelper($View);
+        $this->BcForm = new BcFormHelper($View);
     }
 
     /**

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcFormHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcFormHelperTest.php
@@ -52,6 +52,9 @@ class BcFormHelperTest extends BcTestCase
     {
         parent::setUp();
         $View = new BcAdminAppView($this->getRequest('/contacts/add'));
+        $View->setRequest($View->getRequest()->withAttribute('formTokenData', [
+            'unlockedFields' => [],
+        ]));
         $eventedView = $View->setEventManager(EventManager::instance()->on(new BcContentsEventListener())->setEventList(new EventList()));
         $this->BcForm = new BcFormHelper($eventedView);
     }
@@ -128,6 +131,7 @@ class BcFormHelperTest extends BcTestCase
      */
     public function testDateTimePicker($fieldName, $attributes, $expected, $message)
     {
+        $this->BcForm->create();
         $result = $this->BcForm->dateTimePicker($fieldName, $attributes);
         $this->assertMatchesRegularExpression('/' . $expected . '/s', $result, $message);
     }


### PR DESCRIPTION
dateTimePickerの、jsで動的に値を変更している箇所でエラーになっていたので修正しました。

テストに追加したformTokenDataが分かりづらいのですが、これがないとセキュリティコンポーネントが読み込まれていないというエラーが出てしまうため追加しています。

cakeやbaserの他の箇所でも使われているようです。
https://github.com/cakephp/cakephp/blob/4.x/tests/TestCase/View/Helper/FormHelperTest.php#L226
https://github.com/baserproject/ucmitz/blob/dev/plugins/baser-core/tests/TestCase/View/Helper/BcFormHelperTest.php#L240

ご確認よろしくお願いします。
