### PR TITLE
fix #624 固定ページの親フォルダの公開期間表示がおかしい

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/element/content_fields.php
+++ b/plugins/bc-admin-third/templates/Admin/element/content_fields.php
@@ -195,9 +195,9 @@ $editable = $this->BcContents->isEditable($content);
         <?php if (($this->BcAdminForm->getSourceValue($entityName . "publish_begin") != $this->BcAdminForm->getSourceValue($entityName . "self_publish_begin")) ||
           ($this->BcAdminForm->getSourceValue($entityName . "publish_end") != $this->BcAdminForm->getSourceValue($entityName . "self_publish_end"))): ?>
           <p>※ <?php echo __d('baser', '親フォルダの設定を継承し公開期間が設定されている状態となっています') ?><br>
-            （<?php echo $this->BcTime->format($content->publish_begin, 'yyyy/MM/DD HH:mm') ?>
+            （<?php echo $this->BcTime->format($content->publish_begin, 'yyyy/MM/dd HH:mm') ?>
             〜
-            <?php echo $this->BcTime->format($content->publish_end, 'yyyy/MM/DD HH:mm') ?>）
+            <?php echo $this->BcTime->format($content->publish_end, 'yyyy/MM/dd HH:mm') ?>）
           </p>
         <?php endif ?>
       </td>


### PR DESCRIPTION
前回は時間の表示を調整したのですが、日付の方も対応が必要でしたので調整しています。
前回: https://github.com/baserproject/ucmitz/pull/627/files

お手数ですがご確認お願いします。