### PR TITLE
fix #538 BcBaserHelperのgetLinkのescapeをデフォルトでtrueにしたい

### DIFF
--- a/plugins/baser-core/src/View/Helper/BcBaserHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcBaserHelper.php
@@ -323,8 +323,9 @@ class BcBaserHelper extends Helper
      * @param string $title タイトル
      * @param mixed $url オプション（初期値 : null）
      * @param array $htmlAttributes オプション（初期値 : array()）
-     *    - `escape` : タイトルをエスケープするかどうか（初期値 : false）
-     *  - `prefix` : URLにプレフィックスをつけるかどうか（初期値 : false）
+     *    - `escape` : タイトルとHTML属性をエスケープするかどうか（初期値 : true）
+     *    - `escapeTitle` : タイトルをエスケープするかどうか（初期値 : true）
+     *    - `prefix` : URLにプレフィックスをつけるかどうか（初期値 : false）
      *    - `forceTitle` : 許可されていないURLの際にタイトルを強制的に出力するかどうか（初期値 : false）
      *    - `ssl` : SSL用のURLをして出力するかどうか（初期値 : false）
      *     ※ その他のパラメータについては、HtmlHelper::link() を参照。
@@ -347,8 +348,9 @@ class BcBaserHelper extends Helper
      * @param string $title タイトル
      * @param mixed $url オプション（初期値 : null）
      * @param array $options オプション（初期値 : array()）
-     *    - `escape` : タイトルをエスケープするかどうか（初期値 : false）
-     *  - `prefix` : URLにプレフィックスをつけるかどうか（初期値 : false）
+     *    - `escape` : タイトルとHTML属性をエスケープするかどうか（初期値 : true）
+     *    - `escapeTitle` : タイトルをエスケープするかどうか（初期値 : true）
+     *    - `prefix` : URLにプレフィックスをつけるかどうか（初期値 : false）
      *    - `forceTitle` : 許可されていないURLの際にタイトルを強制的に出力するかどうか（初期値 : false）
      *    - `ssl` : SSL用のURLをして出力するかどうか（初期値 : false）
      *     ※ その他のパラメータについては、HtmlHelper::image() を参照。
@@ -369,7 +371,7 @@ class BcBaserHelper extends Helper
         }
 
         $options = array_merge([
-            'escape' => false,
+            'escape' => true,
             'prefix' => false,
             'forceTitle' => false,
             'ssl' => $this->isSSL()
@@ -2485,6 +2487,7 @@ END_FLASH;
             if ($options['alt']) {
                 $linkOptions['title'] = $options['alt'];
             }
+            $linkOptions['escapeTitle'] = false;
             $tag = $this->getLink($tag, $link, $linkOptions);
         }
         return $tag;

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcBaserHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcBaserHelperTest.php
@@ -405,6 +405,9 @@ class BcBaserHelperTest extends BcTestCase
             ['', '/', [], '<a href="/"></a>'],
             ['会社案内', '/about', [], '<a href="/about">会社案内</a>'],
             ['会社案内 & 会社データ', '/about', ['escape' => true], '<a href="/about">会社案内 &amp; 会社データ</a>'],    // エスケープ
+            ['<b>title</b>', 'https://example.com/<b>link</b>', [], '<a href="https://example.com/&lt;b&gt;link&lt;/b&gt;">&lt;b&gt;title&lt;/b&gt;</a>'], // エスケープ
+            ['<b>title</b>', 'https://example.com/<b>link</b>', ['escape' => false], '<a href="https://example.com/<b>link</b>"><b>title</b></a>'], // エスケープ
+            ['<b>title</b>', 'https://example.com/<b>link</b>', ['escapeTitle' => false], '<a href="https://example.com/&lt;b&gt;link&lt;/b&gt;"><b>title</b></a>'], // エスケープ
             ['固定ページ管理', ['controller' => 'pages', 'action' => 'index'], ['prefix' => true], '<a href="/admin/pages/">固定ページ管理</a>'],    // プレフィックス
             ['システム設定', ['admin' => true, 'controller' => 'site_configs', 'action' => 'form'], ['forceTitle' => true], '<span>システム設定</span>'],    // 強制タイトル
             ['会社案内', '/about', ['ssl' => true], '<a href="https://localhost/about">会社案内</a>'], // SSL


### PR DESCRIPTION
issue: https://github.com/baserproject/ucmitz/issues/538

4系の際は後方互換のために呼び出し元に引数を追加する形で対応したのですが、ucmitzは今のうちにescapeをデフォルトtrueにしておいたほうがいいかと思います。
https://github.com/baserproject/basercms/pull/1814/files#diff-4558f6d3d8f7c006eb2ddb17ccf35f6a1807fc99dea809c8d72bbe4304a4bd72
ご確認お願いします。

## 変更点

- BcBaserHelper::getLinkのescapeをデフォルトtrueに変更
	- それに伴いコメント変更
- テストパターン追加
	- getLinkがまだTODO残っているせいか、テストにmarkTestIncompleteが設定されているので、パターンのみ追加
- BcBaserHelper::getThemeImageにescapeTitle falseを設定
