### PR TITLE
fix #633 ユーザー編集 グループ欄にニックネームが表示される

### DIFF
--- a/plugins/baser-core/src/Service/UsersAdminService.php
+++ b/plugins/baser-core/src/Service/UsersAdminService.php
@@ -15,6 +15,7 @@ use BaserCore\Utility\BcUtil;
 use BaserCore\Annotation\NoTodo;
 use BaserCore\Annotation\Checked;
 use BaserCore\Annotation\UnitTest;
+use BaserCore\Utility\BcContainerTrait;
 use Cake\Datasource\EntityInterface;
 
 /**
@@ -22,6 +23,20 @@ use Cake\Datasource\EntityInterface;
  */
 class UsersAdminService extends UsersService implements UsersAdminServiceInterface
 {
+
+    /**
+     * Trait
+     */
+    use BcContainerTrait;
+
+    /**
+     * Pageservice constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->UserGroupsService = $this->getService(UserGroupsServiceInterface::class);
+    }
 
     /**
      * ログインユーザー自身のIDか確認
@@ -97,7 +112,7 @@ class UsersAdminService extends UsersService implements UsersAdminServiceInterfa
     {
         return [
             'user' => $user,
-            'userGroupList' => $this->getList(),
+            'userGroupList' => $this->UserGroupsService->getList(),
             'isUserGroupEditable' => $this->isUserGroupEditable($user->id),
             'isDeletable' => $this->isDeletable($user->id)
         ];
@@ -114,7 +129,7 @@ class UsersAdminService extends UsersService implements UsersAdminServiceInterfa
     {
         return [
             'user' => $user,
-            'userGroupList' => $this->getList(),
+            'userGroupList' => $this->UserGroupsService->getList(),
             'isUserGroupEditable' => $this->isUserGroupEditable(null),
         ];
     }

--- a/plugins/baser-core/tests/TestCase/Service/UsersAdminServiceTest.php
+++ b/plugins/baser-core/tests/TestCase/Service/UsersAdminServiceTest.php
@@ -169,6 +169,12 @@ class UsersAdminServiceTest extends BcTestCase
     public function test_getViewVarsForEdit()
     {
         $this->assertTrue(count($this->Users->getViewVarsForEdit($this->Users->get(1))) >= 3);
+
+        $this->assertEquals([
+            1 => 'システム管理',
+            2 => 'サイト運営者',
+            3 => 'その他のグループ',
+        ], $this->Users->getViewVarsForEdit($this->Users->get(1))['userGroupList']);
     }
 
     /**
@@ -177,6 +183,12 @@ class UsersAdminServiceTest extends BcTestCase
     public function test_getViewVarsForAdd()
     {
         $this->assertTrue(count($this->Users->getViewVarsForAdd($this->Users->getNew())) >= 2);
+
+        $this->assertEquals([
+            1 => 'システム管理',
+            2 => 'サイト運営者',
+            3 => 'その他のグループ',
+        ], $this->Users->getViewVarsForEdit($this->Users->get(1))['userGroupList']);
     }
 
 }


### PR DESCRIPTION
issue: https://github.com/baserproject/ucmitz/issues/633

ユーザーグループの一覧が必要な箇所でユーザーの一覧を取得していたので修正しています。
ご確認お願いします。