### PR TITLE
fix #580 BcBaserHelper::root と BcBaserHelper::baseUrl を統一できないか検討

### DIFF
--- a/plugins/baser-core/config/theme/bccolumn/Blog/topics/archives.php
+++ b/plugins/baser-core/config/theme/bccolumn/Blog/topics/archives.php
@@ -19,7 +19,7 @@ $(function(){
 	<?php foreach ($posts as $post): ?>
 		<div class="post">
 			<h3><?php $this->Blog->postTitle($post) ?></h3>
-			<?php $uri = $this->BcBaser->getRoot().$this->request->getParam('Content.name').'/archives/'.$post['BlogPost']['no']; ?>
+			<?php $uri = $this->BcBaser->getBaseUrl().$this->request->getParam('Content.name').'/archives/'.$post['BlogPost']['no']; ?>
 			<div class="eye-catch">
 				<a href="<?php echo $uri ?>">
 					<?php $this->Blog->eyeCatch($post, array('link'=>false, 'width'=>'80px')) ?>

--- a/plugins/baser-core/config/theme/bccolumn/Blog/topics/index.php
+++ b/plugins/baser-core/config/theme/bccolumn/Blog/topics/index.php
@@ -17,7 +17,7 @@ $(function(){
 	<?php foreach ($posts as $post): ?>
 		<div class="post">
 			<h2><?php $this->Blog->postTitle($post) ?></h2>
-			<?php $uri = $this->BcBaser->getRoot().$this->request->getParam('Content.name').'/archives/'.$post['BlogPost']['no']; ?>
+			<?php $uri = $this->BcBaser->getBaseUrl().$this->request->getParam('Content.name').'/archives/'.$post['BlogPost']['no']; ?>
 			<div class="eye-catch">
 				<a href="<?php echo $uri ?>">
 					<?php $this->Blog->eyeCatch($post, array('link'=>false, 'width'=>'80px')) ?>

--- a/plugins/baser-core/config/theme/bccolumn/Blog/works/archives.php
+++ b/plugins/baser-core/config/theme/bccolumn/Blog/works/archives.php
@@ -23,7 +23,7 @@ $(function(){
 			</div>
 			<h3><?php $this->Blog->postTitle($post) ?></h3>
 			<?php $this->BcBaser->element('blog_tag', array('post' => $post)) ?>
-			<?php $uri = $this->BcBaser->getRoot().$this->request->getParam('Content.name').'/archives/'.$post['BlogPost']['no']; ?>
+			<?php $uri = $this->BcBaser->getBaseUrl().$this->request->getParam('Content.name').'/archives/'.$post['BlogPost']['no']; ?>
 			<div class="eye-catch">
 				<a href="<?php echo $uri ?>">
 					<?php $this->Blog->eyeCatch($post, array('link'=>false, 'width'=>'150px', 'noimage'=>'/theme/bccolumn/img/blog/works/noimage.png')) ?>

--- a/plugins/baser-core/config/theme/bccolumn/Blog/works/index.php
+++ b/plugins/baser-core/config/theme/bccolumn/Blog/works/index.php
@@ -21,7 +21,7 @@ $(function(){
 			</div>
 			<h2><?php $this->Blog->postTitle($post) ?></h2>
 			<?php $this->BcBaser->element('blog_tag', array('post' => $post)) ?>
-			<?php $uri = $this->BcBaser->getRoot().$this->request->getParam('Content.name').'/archives/'.$post['BlogPost']['no']; ?>
+			<?php $uri = $this->BcBaser->getBaseUrl().$this->request->getParam('Content.name').'/archives/'.$post['BlogPost']['no']; ?>
 			<div class="eye-catch">
 				<a href="<?php echo $uri ?>">
 					<?php $this->Blog->eyeCatch($post, array('link'=>false, 'width'=>'150px', 'noimage'=>'/theme/bccolumn/img/blog/works/noimage.png')) ?>

--- a/plugins/baser-core/src/View/Helper/BcBaserHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcBaserHelper.php
@@ -1144,41 +1144,6 @@ class BcBaserHelper extends Helper
     }
 
     /**
-     * baserCMSが設置されているパスを出力する
-     *
-     * BcBaserHelper::getRoot() をラッピングして出力するだけの処理
-     *
-     * @return void
-     */
-    public function root()
-    {
-        echo $this->getRoot();
-    }
-
-    /**
-     * baserCMSが設置されているパスを取得する
-     *
-     * 画像タグやリンクタグを出力する際に、baserCMSの設置フォルダに
-     * 依存せずパスを出力する為に利用する。
-     *
-     * 《利用例》
-     * <img src="<?php echo $this->BcBaser->root() ?>img/test.png" />
-     *
-     * 《basercmsというフォルダに設置している場合の取得例》
-     * /basercms/
-     *
-     * @return string
-     * @checked
-     * @noTodo
-     * @unitTest
-     * @doc
-     */
-    public function getRoot(): string
-    {
-        return $this->_View->getRequest()->getAttribute('base') . '/';
-    }
-
-    /**
      * ヘッダーテンプレートを出力する
      *
      * @param array $data エレメントで参照するデータ

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcBaserHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcBaserHelperTest.php
@@ -1140,16 +1140,6 @@ class BcBaserHelperTest extends BcTestCase
     }
 
     /**
-     * baserCMSが設置されているパスを取得する
-     * @param string $expected 期待値
-     * @return void
-     */
-    public function testGetRoot()
-    {
-        $this->assertEquals('/', $this->BcBaser->getRoot());
-    }
-
-    /**
      * ヘッダーテンプレートを出力する
      *
      * @return void


### PR DESCRIPTION
issue: https://github.com/baserproject/ucmitz/issues/580

BcBaserHelperのrootとgetRootを削除しました。
ご確認お願いします。