### PR TITLE
ユーザー一覧 グループ名のエスケープ追加

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/element/Users/index_row.php
+++ b/plugins/bc-admin-third/templates/Admin/element/Users/index_row.php
@@ -29,7 +29,7 @@ use BaserCore\View\AppView;
     <?php if (!empty($user->user_groups)): ?>
       <ul class="user_group">
         <?php foreach($user->user_groups as $userGroups): ?>
-          <li><?php echo $userGroups->title; ?></li>
+          <li><?php echo h($userGroups->title); ?></li>
         <?php endforeach; ?>
       </ul>
     <?php endif; ?>


### PR DESCRIPTION
グループ名にHTMLタグが含まれているとタグが表示されてしまったので調整しました。
ご確認お願いします。