### PR TITLE
fix #581 BcBaserHelper::getParams分割

### DIFF
--- a/plugins/baser-core/src/View/Helper/BcBaserHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcBaserHelper.php
@@ -2709,18 +2709,9 @@ END_FLASH;
     }
 
     /**
-     * URLのパラメータ情報を返す
-     * 主なreturnデータは
-     * https://basercms.net/news/index/example/test?name=value の場合
-     * 'plugin' => blog (利用しているプラグイン)
-     * 'pass' => [0] => 'example'
-     *           [1] => 'test'
-     * 'isAjax' => (boolean)false
-     * 'query' => 'name' => 'value'
-     * 'url' => 'news/index/fuga/hoge'
-     * 'here' => '/news/index/fuga/hoge'
+     * パラメータ情報を取得する
      *
-     * @return array URLのパラメータ情報の配列
+     * @return array パラメータ情報の配列
      * @checked
      * @noTodo
      * @unitTest
@@ -2728,17 +2719,27 @@ END_FLASH;
     public function getParams()
     {
         $attributes = $this->_View->getRequest()->getAttributes();
-        $params = $attributes['params'];
-        $params['query'] = $this->_View->getRequest()->getQueryParams();
-        $params['url'] = preg_replace('/^\//', '', $this->_View->getRequest()->getPath());
-        $params['here'] = $this->_View->getRequest()->getPath();
-        unset($params['named']);
-        unset($params['controller']);
-        unset($params['action']);
-        unset($params['models']);
-        unset($params['_Token']);
-        unset($params['paging']);
-        return $params;
+        return $attributes['params'];
+    }
+
+    /**
+     * URL情報を取得する
+     *
+     * @return array URL情報の配列
+     * @checked
+     * @noTodo
+     * @unitTest
+     */
+    public function getUrlParams()
+    {
+        $attributes = $this->_View->getRequest()->getAttributes();
+        return [
+            'url' => $this->getUrl(null, true),
+            'here' => $attributes['here'],
+            'webroot' => $attributes['webroot'],
+            'base' => $attributes['base'],
+            'query' => $this->_View->getRequest()->getQueryParams(),
+        ];
     }
 
     /**

--- a/plugins/baser-core/src/View/Helper/BcBaserHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcBaserHelper.php
@@ -2736,6 +2736,7 @@ END_FLASH;
         return [
             'url' => $this->getUrl(null, true),
             'here' => $attributes['here'],
+            'path' => $this->_View->getRequest()->getPath(),
             'webroot' => $attributes['webroot'],
             'base' => $attributes['base'],
             'query' => $this->_View->getRequest()->getQueryParams(),

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcBaserHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcBaserHelperTest.php
@@ -2238,13 +2238,14 @@ class BcBaserHelperTest extends BcTestCase
      * URL情報を取得する
      * @return void
      */
-    public function testUrlGetParams()
+    public function testGetUrlParams()
     {
         $this->BcBaser->getView()->setRequest($this->getRequest('/?a=b'));
         $urlParams = $this->BcBaser->getUrlParams();
         $this->assertEquals([
             'url' => 'https://localhost/?a=b',
             'here' => '/',
+            'path' => '/',
             'webroot' => '',
             'base' => '',
             'query' => [
@@ -2252,13 +2253,16 @@ class BcBaserHelperTest extends BcTestCase
             ],
         ], $urlParams);
 
-        $this->BcBaser->getView()->setRequest($this->getRequest('/test'));
+        $this->BcBaser->getView()->setRequest(
+            $this->getRequest('/test', [], null, ['base' => '/baser', 'webroot' => '/baser/'])
+        );
         $urlParams = $this->BcBaser->getUrlParams();
         $this->assertEquals([
-            'url' => 'https://localhost/test',
-            'here' => '/test',
-            'webroot' => '',
-            'base' => '',
+            'url' => 'https://localhost/baser/test',
+            'here' => '/baser/test',
+            'path' => '/test',
+            'webroot' => '/baser/',
+            'base' => '/baser',
             'query' => [],
         ], $urlParams);
     }

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcBaserHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcBaserHelperTest.php
@@ -2221,18 +2221,46 @@ class BcBaserHelperTest extends BcTestCase
     }
 
     /**
-     * URLのパラメータ情報を返す
+     * パラメータ情報を取得する
      * @return void
      */
     public function testGetParams()
     {
-        $this->BcBaser->getView()->setRequest($this->getRequest('/?name=value'));
+        $this->BcBaser->getView()->setRequest($this->getRequest('/'));
         $params = $this->BcBaser->getParams();
         $this->assertEquals('BaserCore', $params['plugin']);
+        $this->assertEquals('Pages', $params['controller']);
+        $this->assertEquals('display', $params['action']);
         $this->assertEquals(['index'], $params['pass']);
-        $this->assertEquals('value', $params['query']['name']);
-        $this->assertEquals('', $params['url']);
-        $this->assertEquals('/', $params['here']);
+    }
+
+    /**
+     * URL情報を取得する
+     * @return void
+     */
+    public function testUrlGetParams()
+    {
+        $this->BcBaser->getView()->setRequest($this->getRequest('/?a=b'));
+        $urlParams = $this->BcBaser->getUrlParams();
+        $this->assertEquals([
+            'url' => 'https://localhost/?a=b',
+            'here' => '/',
+            'webroot' => '',
+            'base' => '',
+            'query' => [
+                'a' => 'b',
+            ],
+        ], $urlParams);
+
+        $this->BcBaser->getView()->setRequest($this->getRequest('/test'));
+        $urlParams = $this->BcBaser->getUrlParams();
+        $this->assertEquals([
+            'url' => 'https://localhost/test',
+            'here' => '/test',
+            'webroot' => '',
+            'base' => '',
+            'query' => [],
+        ], $urlParams);
     }
 
     /**


### PR DESCRIPTION
ご確認お願いします。

issue: https://github.com/baserproject/ucmitz/issues/581

## 変更点

- https://github.com/baserproject/ucmitz/issues/581#issuecomment-1162590459
- 返り値の「url」の仕様を4系から変更
	- 4系ではurlとhereの違いは「/」の有無のみ
	- http〜やクエリストリングも入った現在のURL全体を返すよう変更
