### PR TITLE
コンテンツ削除時の処理を調整

### DIFF
--- a/plugins/baser-core/src/Controller/Admin/ContentsController.php
+++ b/plugins/baser-core/src/Controller/Admin/ContentsController.php
@@ -404,41 +404,4 @@ class ContentsController extends BcAdminAppController
         }
         return $this->response->withStringBody('true');
     }
-
-    /**
-     * ゴミ箱を空にする
-     * @see bcTreeの処理はApi/trash_emptyに移行
-     * @param ContentsServiceInterface $contentService
-     * @return Response|null
-     * @checked
-     * @noTodo
-     * @unitTest
-     */
-    public function trash_empty(ContentsServiceInterface $contentService)
-    {
-        $this->disableAutoRender();
-        if (!$this->request->getData()) {
-            $this->notFound();
-        }
-        $contents = $contentService->getTrashIndex()->order(['plugin', 'type']);
-
-        // EVENT Contents.beforetrash_empty
-        $this->dispatchLayerEvent('beforetrash_empty', [
-            'data' => $contents
-        ]);
-        if ($contents) {
-            $result = true;
-            foreach($contents as $content) {
-                if(!$contentService->hardDeleteWithAssoc($content->id)) {
-                    $result = false;
-                    $this->BcMessage->setError(__d('baser', 'ゴミ箱の削除に失敗しました'));
-                }
-            }
-        }
-        // EVENT Contents.aftertrash_empty
-        $this->dispatchLayerEvent('aftertrash_empty', [
-            'data' => $result
-        ]);
-        return $this->redirect(['action' => "trash_index"]);
-    }
 }

--- a/plugins/baser-core/src/Controller/Api/ContentsController.php
+++ b/plugins/baser-core/src/Controller/Api/ContentsController.php
@@ -166,13 +166,19 @@ class ContentsController extends BcApiController
         $this->request->allowMethod(['post', 'delete']);
         $trash = $contentService->getTrashIndex($this->request->getQueryParams())->order(['plugin', 'type']);
         $text = "ゴミ箱: ";
+        // EVENT Contents.beforetrash_empty
+        $this->dispatchLayerEvent('beforetrash_empty', [
+            'data' => $trash
+        ]);
         try {
             foreach ($trash as $entity) {
-                if ($contentService->hardDeleteWithAssoc($entity->id)) {
-                    $text .=  "$entity->title($entity->type)" . "を削除しました。";
-                    }
+                $contentService->hardDeleteWithAssoc($entity->id);
             }
-            $message = __d('baser', $text);
+            $message = __d('baser', 'ゴミ箱を空にしました。');
+            // EVENT Contents.aftertrash_empty
+            $this->dispatchLayerEvent('aftertrash_empty', [
+                'data' => $result
+            ]);
         } catch (Exception $e) {
             $this->setResponse($this->response->withStatus(500));
             $message = __d('baser', 'データベース処理中にエラーが発生しました。') . $e->getMessage();

--- a/plugins/baser-core/src/Service/ContentsService.php
+++ b/plugins/baser-core/src/Service/ContentsService.php
@@ -443,24 +443,19 @@ class ContentsService implements ContentsServiceInterface
         /* @var Content $content */
         $content = $this->getTrash($id);
         $service = $content->plugin . '\\Service\\' . Inflector::pluralize($content->type) . 'ServiceInterface';
-        if(interface_exists($service)) {
+        if (interface_exists($service)) {
             $target = $this->getService($service);
         } else {
             $target = TableRegistry::getTableLocator()->get($content->plugin . '.' . Inflector::pluralize($content->type));
         }
-        $result = false;
-        if($target) {
-            try {
-                if(is_a($target, 'Cake\ORM\Table')) {
-                    $result = $target->delete($content);
-                } else {
-                    $result = $target->delete($content->entity_id);
-                }
-            } catch (\Exception $e) {
-                $result = false;
-            }
+        if (!$target) {
+            throw new \Cake\Datasource\Exception\RecordNotFoundException();
         }
-        return $result;
+        if (is_a($target, 'Cake\ORM\Table')) {
+            return $target->delete($content);
+        } else {
+            return $target->delete($content->entity_id);
+        }
     }
 
 

--- a/plugins/baser-core/tests/TestCase/Controller/Admin/ContentsControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/Admin/ContentsControllerTest.php
@@ -476,21 +476,6 @@ class ContentsControllerTest extends BcTestCase
     }
 
     /**
-     * ゴミ箱を空にする
-     */
-    public function testTrash_empty()
-    {
-        // BcAdminContentsTestはコンポネントのテスト用のため、一旦復活させtrash_emptyを実行
-        $this->ContentsService->restoreAll(['type' => 'BcAdminContentsTest']);
-        $this->request = $this->request->withData('test', 'テスト');
-        $this->ContentsController->setRequest($this->request);
-        $response = $this->ContentsController->trash_empty($this->ContentsService);
-        $this->assertTrue($this->ContentsService->getTrashIndex(['type' => "ContentFolder"])->all()->isEmpty());
-        $this->assertEquals(8, $this->ContentFoldersService->getIndex()->count());
-        $this->assertStringContainsString("/baser/admin/baser-core/contents/trash_index", $response->getHeaderLine('Location'));
-    }
-
-    /**
      * コンテンツ表示
      */
     public function testView()

--- a/plugins/baser-core/tests/TestCase/Controller/Api/ContentsControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/Api/ContentsControllerTest.php
@@ -198,7 +198,7 @@ class ContentsControllerTest extends \BaserCore\TestSuite\BcTestCase
         $this->post('/baser/api/baser-core/contents/trash_empty.json?type=ContentFolder&token=' . $this->accessToken);
         $this->assertResponseOk();
         $result = json_decode((string)$this->_response->getBody());
-        $this->assertEquals("ゴミ箱: 削除済みフォルダー(親)(ContentFolder)を削除しました。削除済みフォルダー(子)(ContentFolder)を削除しました。", $result->message);
+        $this->assertEquals("ゴミ箱を空にしました。", $result->message);
         $this->get('/baser/api/baser-core/contents/index/trash.json?type=ContentFolder&token=' . $this->accessToken);
         $result = json_decode((string)$this->_response->getBody());
         $this->assertEmpty($result->contents);

--- a/plugins/baser-core/tests/TestCase/Service/ContentsServiceTest.php
+++ b/plugins/baser-core/tests/TestCase/Service/ContentsServiceTest.php
@@ -323,10 +323,24 @@ class ContentsServiceTest extends BcTestCase
     {
         $content = $this->ContentsService->getTrash(16);
         $this->assertTrue($this->ContentsService->hardDeleteWithAssoc(16));
-        $this->expectException('Cake\Datasource\Exception\RecordNotFoundException');
-        $this->ContentsService->getTrash(16);
-        $this->expectException('Cake\Datasource\Exception\RecordNotFoundException');
-        $this->ContentFoldersService->get($content->entity_id);
+        try {
+            $this->ContentsService->getTrash(16);
+            throw new \Exception();
+        } catch (\Exception $e) {
+            $this->assertSame('Cake\Datasource\Exception\RecordNotFoundException', get_class($e));
+        }
+        try {
+            $this->ContentFoldersService->get($content->entity_id);
+            throw new \Exception();
+        } catch (\Exception $e) {
+            $this->assertSame('Cake\Datasource\Exception\RecordNotFoundException', get_class($e));
+        }
+        try {
+            $this->assertTrue($this->ContentsService->hardDeleteWithAssoc(999));
+            throw new \Exception();
+        } catch (\Exception $e) {
+            $this->assertSame('Cake\Datasource\Exception\RecordNotFoundException', get_class($e));
+        }
     }
 
     /**


### PR DESCRIPTION
以下調整しました。ご確認お願いします。

- Admin/ContentsController->trash_empty を削除
	- Api/ContentsController->trash_empty の方を使用しているため
- Adminの方にしかなかったイベントをApiの方に移動
- ゴミ箱を空にする際のメッセージが長い問題を修正
- ContentsService->hardDeleteWithAssoc の処理が失敗した際にthrowするよう変更
	- 他の保存・削除時の処理と仕様を合わせるため
- ContentsService->hardDeleteWithAssoc のテストで実行されていないテストが存在したので修正
	- 関連issue: https://github.com/baserproject/basercms/issues/1928

ゴミ箱を空にする際のメッセージが長い問題

<img width="966" alt="1" src="https://user-images.githubusercontent.com/30764014/176393631-b884beb9-3fac-4ade-80f3-22cd15c20020.png">
