### PR TITLE
fix #557 BcBaserHelper::cssに$inline引数を追加

### DIFF
--- a/plugins/baser-core/config/theme/bccolumn/Mail/default/confirm.php
+++ b/plugins/baser-core/config/theme/bccolumn/Mail/default/confirm.php
@@ -2,7 +2,7 @@
 /**
  * メールフォーム確認ページ
  */
-$this->BcBaser->css('admin/jquery-ui/jquery-ui.min', array('inline' => true));
+$this->BcBaser->css('admin/jquery-ui/jquery-ui.min', true);
 $this->BcBaser->js(array('vendor/jquery-ui-1.11.4.min', 'vendor/i18n/ui.datepicker-ja'), false);
 if ($freezed) {
 	$this->Mailform->freeze();

--- a/plugins/baser-core/config/theme/bccolumn/Mail/default/index.php
+++ b/plugins/baser-core/config/theme/bccolumn/Mail/default/index.php
@@ -2,7 +2,7 @@
 /**
  * メールフォーム
  */
-$this->BcBaser->css('admin/jquery-ui/jquery-ui.min', array('inline' => true));
+$this->BcBaser->css('admin/jquery-ui/jquery-ui.min', true);
 $this->BcBaser->js(array('vendor/jquery-ui-1.11.4.min', 'vendor/i18n/ui.datepicker-ja'), false);
 ?>
 

--- a/plugins/baser-core/config/theme/nada-icons/Blog/default/archives.php
+++ b/plugins/baser-core/config/theme/nada-icons/Blog/default/archives.php
@@ -2,7 +2,7 @@
 /**
  * ブログアーカイブ一覧
  */
-$this->BcBaser->css('colorbox/colorbox', array('inline' => false));
+$this->BcBaser->css('colorbox/colorbox', false);
 $this->BcBaser->js('jquery.colorbox-min-1.4.5', false);
 $this->BcBaser->setDescription($this->Blog->getTitle() . '｜' . $this->BcBaser->getContentsTitle() .  __('のアーカイブ一覧です。'));
 ?>
@@ -27,7 +27,7 @@ $(function(){
 			<?php $this->Blog->postTitle($post) ?>
 			</h4>
 		<?php $this->Blog->postContent($post, true, true) ?>
-			<div class="meta"> 
+			<div class="meta">
 				<span class="date">
 		<?php $this->Blog->postDate($post) ?>
 				</span>

--- a/plugins/baser-core/config/theme/nada-icons/Blog/default/index.php
+++ b/plugins/baser-core/config/theme/nada-icons/Blog/default/index.php
@@ -2,7 +2,7 @@
 /**
  * ブログトップ
  */
-$this->BcBaser->css('colorbox/colorbox', array('inline' => false));
+$this->BcBaser->css('colorbox/colorbox', false);
 $this->BcBaser->js('jquery.colorbox-min-1.4.5', false);
 $this->BcBaser->setDescription($this->Blog->getDescription());
 ?>
@@ -30,7 +30,7 @@ $(function(){
 			<?php $this->Blog->postTitle($post) ?>
 			</h4>
 		<?php $this->Blog->postContent($post, true, true) ?>
-			<div class="meta"> 
+			<div class="meta">
 				<span class="date">
 		<?php $this->Blog->postDate($post) ?>
 				</span>

--- a/plugins/baser-core/config/theme/nada-icons/Blog/default/single.php
+++ b/plugins/baser-core/config/theme/nada-icons/Blog/default/single.php
@@ -2,7 +2,7 @@
 /**
  * ブログ詳細ページ
  */
-$this->BcBaser->css('colorbox/colorbox', array('inline' => false));
+$this->BcBaser->css('colorbox/colorbox', false);
 $this->BcBaser->js('jquery.colorbox-min-1.4.5', false);
 $this->BcBaser->setDescription($this->Blog->getTitle() . '｜' . $this->Blog->getPostContent($post, false, false, 50));
 ?>
@@ -28,7 +28,7 @@ $(function(){
 
 <div class="post">
 <?php $this->Blog->postContent($post) ?>
-	<div class="meta"> 
+	<div class="meta">
 		<span class="date">
 <?php $this->Blog->postDate($post) ?>
 		</span>

--- a/plugins/baser-core/config/theme/nada-icons/Blog/tags.php
+++ b/plugins/baser-core/config/theme/nada-icons/Blog/tags.php
@@ -15,7 +15,7 @@
  *
  * @var BcAppView $this
  */
-$this->BcBaser->css(array('Blog.style'), array('inline' => false));
+$this->BcBaser->css(array('Blog.style'), false);
 $this->BcBaser->setDescription($this->BcBaser->getContentsTitle() . __('のアーカイブ一覧です。'));
 ?>
 

--- a/plugins/baser-core/config/theme/nada-icons/Mail/default/confirm.php
+++ b/plugins/baser-core/config/theme/nada-icons/Mail/default/confirm.php
@@ -2,7 +2,7 @@
 /**
  * メールフォーム確認ページ
  */
-$this->BcBaser->css('admin/jquery-ui/jquery-ui.min', array('inline' => true));
+$this->BcBaser->css('admin/jquery-ui/jquery-ui.min', true);
 $this->BcBaser->js(array('vendor/jquery-ui-1.11.4.min', 'vendor/i18n/ui.datepicker-ja'), false);
 if ($freezed) {
 	$this->Mailform->freeze();

--- a/plugins/baser-core/config/theme/nada-icons/Mail/default/index.php
+++ b/plugins/baser-core/config/theme/nada-icons/Mail/default/index.php
@@ -2,7 +2,7 @@
 /**
  * メールフォーム
  */
-$this->BcBaser->css('admin/jquery-ui/jquery-ui.min', array('inline' => true));
+$this->BcBaser->css('admin/jquery-ui/jquery-ui.min', true);
 $this->BcBaser->js(array('vendor/jquery-ui-1.11.4.min', 'vendor/i18n/ui.datepicker-ja'), false);
 ?>
 

--- a/plugins/baser-core/src/View/Helper/BcBaserHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcBaserHelper.php
@@ -185,7 +185,7 @@ class BcBaserHelper extends Helper
     /**
      * Javascript タグを出力する
      *
-     * @param string|array $url Javascriptのパス（js フォルダからの相対パス）拡張子は省略可
+     * @param string|array $path Javascriptのパス（js フォルダからの相対パス）拡張子は省略可
      * @param bool $inline コンテンツ内に Javascript を出力するかどうか（初期値 : true）
      * @return void
      * @checked
@@ -193,13 +193,12 @@ class BcBaserHelper extends Helper
      * @unitTest
      * @doc
      */
-    public function js($url, $inline = true, $options = [])
+    public function js($path, $inline = true, $options = [])
     {
-        $options = array_merge(['block' => !$inline], $options);
-        $result = $this->BcHtml->script($url, $options);
-        if ($inline) {
-            echo $result;
+        if (!isset($options['block'])) {
+            $options['block'] = $inline ? null : true;
         }
+        echo $this->BcHtml->script($path, $options);
     }
 
     /**
@@ -1270,7 +1269,7 @@ class BcBaserHelper extends Helper
      * コンテンツ内で、レイアウトテンプレートへの出力を設定する場合には、inline オプションを false にする
      *
      * 《利用例》
-     * $this->BcBaser->css('admin/layout', array('inline' => false));
+     * $this->BcBaser->css('admin/layout', false);
      * $this->BcBaser->js('admin/startup', false);
      *
      * @return void
@@ -1435,6 +1434,7 @@ class BcBaserHelper extends Helper
      * $this->BcBaser->css('admin/import')
      *
      * @param mixed $path CSSファイルのパス（css フォルダからの相対パス）拡張子は省略可
+     * @param bool $inline コンテンツ内に Javascript を出力するかどうか（初期値 : true）
      * @param mixed $options オプション
      * ※💣inline=false→block=trueに変更になったため注意 @return string|void
      * @checked
@@ -1447,14 +1447,12 @@ class BcBaserHelper extends Helper
      * - 'inline'=trueを指定する (代替:$options['block']にnullが入る)
      * - 'inline'=falseを指定する (代替:$options['block']にtrueが入る)
      */
-    public function css($path, $options = [])
+    public function css($path, $inline = true, $options = [])
     {
-        if (isset($options['inline'])) {
-            $options['block'] = $options['inline']? null : true;
+        if (!isset($options['block'])) {
+            $options['block'] = $inline ? null : true;
         }
-        $result = $this->BcHtml->css($path, $options);
-
-        echo $result;
+        echo $this->BcHtml->css($path, $options);
     }
 
     /**

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcBaserHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcBaserHelperTest.php
@@ -1398,17 +1398,32 @@ class BcBaserHelperTest extends BcTestCase
         $result = ob_get_clean();
         $expected = '<link rel="stylesheet" href="css/admin/import.css"/>';
         $this->assertEquals($expected, $result);
-        // ブロックオン（array）
+        // インライン
         ob_start();
-        $this->BcBaser->css('admin/import2.css', ['block' => null]);
+        $this->BcBaser->css('admin/import2.css', true);
         $result = ob_get_clean();
         $expected = '<link rel="stylesheet" href="css/admin/import2.css"/>';
         $this->assertEquals($expected, $result);
-        // インラインオフ（array）
+        // ブロック
         ob_start();
-        $this->BcBaser->css('admin/import3.css', ['inline' => false]);
+        $this->BcBaser->css('admin/import3.css', false);
         $result = ob_get_clean();
         $this->assertEmpty($result);
+        $this->assertEquals('<link rel="stylesheet" href="css/admin/import3.css"/>',
+            $this->BcAdminAppView->fetch('css'));
+        // ブロック指定
+        ob_start();
+        $this->BcBaser->css('admin/import4.css', false, ['block' => 'testblock']);
+        $result = ob_get_clean();
+        $this->assertEmpty($result);
+        $this->assertEquals('<link rel="stylesheet" href="css/admin/import4.css"/>',
+            $this->BcAdminAppView->fetch('testblock'));
+        ob_start();
+        $this->BcBaser->css('admin/import5.css', true, ['block' => 'testblock2']);
+        $result = ob_get_clean();
+        $this->assertEmpty($result);
+        $this->assertEquals('<link rel="stylesheet" href="css/admin/import5.css"/>',
+            $this->BcAdminAppView->fetch('testblock2'));
     }
 
     /**

--- a/plugins/bc-admin-third/templates/Admin/BlogPosts/form.php
+++ b/plugins/bc-admin-third/templates/Admin/BlogPosts/form.php
@@ -16,7 +16,7 @@
 $url = $this->request->params['Content']['url'] . 'archives/' . $this->BcForm->getSourceValue('BlogPost.no');
 $fullUrl = $this->BcBaser->getContentsUrl($url, true, $this->request->params['Site']['use_subdomain']);
 $statuses = [0 => __d('baser', '非公開'), 1 => __d('baser', '公開')];
-$this->BcBaser->css('admin/ckeditor/editor', ['inline' => true]);
+$this->BcBaser->css('admin/ckeditor/editor', true);
 $this->BcBaser->i18nScript([
   'alertMessage1' => __d('baser', 'ブログタグの追加に失敗しました。既に登録されていないか確認してください。'),
   'alertMessage2' => __d('baser', 'ブログタグの追加に失敗しました。'),

--- a/plugins/bc-admin-third/templates/Admin/BlogPosts/index.php
+++ b/plugins/bc-admin-third/templates/Admin/BlogPosts/index.php
@@ -13,7 +13,7 @@
 /**
  * [管理画面] ブログ記事 一覧
  */
-$this->BcBaser->css('Blog.admin/style', ['inline' => false]);
+$this->BcBaser->css('Blog.admin/style', false);
 $this->BcBaser->js([
   'admin/libs/jquery.baser_ajax_data_list',
   'admin/libs/jquery.baser_ajax_batch',

--- a/plugins/bc-admin-third/templates/Admin/Contents/index.php
+++ b/plugins/bc-admin-third/templates/Admin/Contents/index.php
@@ -79,7 +79,7 @@ $this->BcBaser->js('admin/contents/index.bundle', false, [
   'data-baserCorePrefix' => Inflector::underscore(BcUtil::getBaserCorePrefix()),
   'data-editInIndexDisabled' => $editInIndexDisabled
 ]);
-$this->BcBaser->css('../js/vendor/jquery.jstree-3.3.8/themes/proton/style.min', ['block' => true]);
+$this->BcBaser->css('../js/vendor/jquery.jstree-3.3.8/themes/proton/style.min', false);
 echo $this->BcAdminForm->control('BcManageContent', ['type' => 'hidden', 'value' => $this->BcContents->getJsonItems()]);
 ?>
 

--- a/plugins/bc-admin-third/templates/Admin/EditorTemplates/form.php
+++ b/plugins/bc-admin-third/templates/Admin/EditorTemplates/form.php
@@ -19,7 +19,7 @@ $this->BcBaser->js('admin/editor_templates/form', false);
 ?>
 
 
-<?php $this->BcBaser->css('admin/ckeditor/editor', ['inline' => true]); ?>
+<?php $this->BcBaser->css('admin/ckeditor/editor', true); ?>
 <?php echo $this->BcAdminForm->create('EditorTemplate', ['type' => 'file']) ?>
 
 <?php echo $this->BcFormTable->dispatchBefore() ?>

--- a/plugins/bc-admin-third/templates/Admin/Pages/form.php
+++ b/plugins/bc-admin-third/templates/Admin/Pages/form.php
@@ -14,7 +14,7 @@ use BaserCore\View\BcAdminAppView;
  * [ADMIN] ページ登録・編集フォーム
  * @var BcAdminAppView $this
  */
-$this->BcBaser->css('admin/ckeditor/editor', ['inline' => true]);
+$this->BcBaser->css('admin/ckeditor/editor', true);
 $this->BcAdmin->setTitle(__d('baser', '固定ページ情報編集'));
 $this->BcAdmin->setHelp('pages_form');
 ?>

--- a/plugins/bc-admin-third/templates/Admin/ThemeConfigs/form.php
+++ b/plugins/bc-admin-third/templates/Admin/ThemeConfigs/form.php
@@ -13,7 +13,7 @@
 /**
  * [ADMIN] テーマ設定編集
  */
-$this->BcBaser->css('admin/colpick', ['inline' => false]);
+$this->BcBaser->css('admin/colpick', false);
 $this->BcBaser->js(['vendor/colpick', 'admin/theme_configs/form'], false);
 ?>
 

--- a/plugins/bc-admin-third/templates/Admin/UploaderFiles/index.php
+++ b/plugins/bc-admin-third/templates/Admin/UploaderFiles/index.php
@@ -9,7 +9,7 @@
  * @since           baserCMS v 3.0.10
  * @license         https://basercms.net/license/index.html
  */
-$this->BcBaser->css('BcUploader.uploader', ['inline' => false]);
+$this->BcBaser->css('BcUploader.uploader', false);
 ?>
 
 <?php $this->BcBaser->element('uploader_files/index') ?>


### PR DESCRIPTION
issue: https://github.com/baserproject/ucmitz/issues/557

BcBaserHelper::cssに$inline引数を追加する対応を行いました。
ご確認お願いします。