### PR TITLE
fix #731 コンテンツ管理ゴミ箱画面 検索 UI 非表示

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/Contents/index.php
+++ b/plugins/bc-admin-third/templates/Admin/Contents/index.php
@@ -22,13 +22,13 @@ use BaserCore\View\BcAdminAppView;
 switch($this->request->getParam('action')) {
   case 'index':
       $this->BcAdmin->setTitle(__d('baser', 'コンテンツ一覧'));
+      $this->BcAdmin->setSearch('contents_index');
       break;
   case 'trash_index':
       $this->BcAdmin->setTitle(__d('baser', 'ゴミ箱'));
       break;
 }
 
-$this->BcAdmin->setSearch('contents_index');
 $this->BcAdmin->setHelp('contents_index');
 
 $editInIndexDisabled = false;


### PR DESCRIPTION
コンテンツ管理ゴミ箱画面の検索 UI を非表示にしました。
ご確認よろしくお願いいたします！