### PR TITLE
fix #794 コンテンツ管理ゴミ箱画面 全サイトコンテンツ表示

### DIFF
--- a/plugins/baser-core/src/Controller/Admin/ContentsController.php
+++ b/plugins/baser-core/src/Controller/Admin/ContentsController.php
@@ -98,7 +98,7 @@ class ContentsController extends BcAdminAppController
     {
         $currentSiteId = $this->request->getAttribute('currentSite')->id;
         $sites = $siteService->getList();
-        if ($sites && $this->request->getParam('action') != "trash_index") {
+        if ($sites) {
             if (!$this->request->getQuery('site_id') || !in_array($this->request->getQuery('site_id'), array_keys($sites))) {
                 reset($sites);
                 $this->request = $this->request->withQueryParams(Hash::merge($this->request->getQueryParams(), ['site_id' =>key($sites)]));

--- a/plugins/baser-core/src/Controller/Admin/ContentsController.php
+++ b/plugins/baser-core/src/Controller/Admin/ContentsController.php
@@ -98,7 +98,7 @@ class ContentsController extends BcAdminAppController
     {
         $currentSiteId = $this->request->getAttribute('currentSite')->id;
         $sites = $siteService->getList();
-        if ($sites) {
+        if ($sites && $this->request->getParam('action') != "trash_index") {
             if (!$this->request->getQuery('site_id') || !in_array($this->request->getQuery('site_id'), array_keys($sites))) {
                 reset($sites);
                 $this->request = $this->request->withQueryParams(Hash::merge($this->request->getQueryParams(), ['site_id' =>key($sites)]));

--- a/plugins/baser-core/src/Service/ContentsService.php
+++ b/plugins/baser-core/src/Service/ContentsService.php
@@ -305,6 +305,7 @@ class ContentsService implements ContentsServiceInterface
     public function getTrashIndex(array $queryParams=[], string $type="all"): Query
     {
         $queryParams = array_merge($queryParams, ['withTrash' => true]);
+        if (isset($queryParams['site_id'])) unset($queryParams['site_id']);
         return $this->getIndex($queryParams, $type)->where(['deleted_date IS NOT NULL']);
     }
 


### PR DESCRIPTION
コンテンツ管理ゴミ箱画面で全サイトのコンテンツが表示されるように変更いたしました。
コンテンツ管理の一覧画面でサイトによる絞り込みを行わず表示するのはゴミ箱画面が例外かと思い、`trash_index` でなければという分岐にしています。
ご確認よろしくお願いいたします！