### PR TITLE
fix #796 コンテンツ管理一覧画面 カレントサイトコンテンツ初期表示

### DIFF
--- a/plugins/baser-core/src/Controller/Admin/ContentsController.php
+++ b/plugins/baser-core/src/Controller/Admin/ContentsController.php
@@ -99,7 +99,9 @@ class ContentsController extends BcAdminAppController
         $currentSiteId = $this->request->getAttribute('currentSite')->id;
         $sites = $siteService->getList();
         if ($sites) {
-            if (!$this->request->getQuery('site_id') || !in_array($this->request->getQuery('site_id'), array_keys($sites))) {
+            if (in_array($currentSiteId, array_keys($sites))) {
+                $this->request = $this->request->withQueryParams(Hash::merge($this->request->getQueryParams(), ['site_id' => $currentSiteId]));
+            } elseif (!$this->request->getQuery('site_id') || !in_array($this->request->getQuery('site_id'), array_keys($sites))) {
                 reset($sites);
                 $this->request = $this->request->withQueryParams(Hash::merge($this->request->getQueryParams(), ['site_id' =>key($sites)]));
             }


### PR DESCRIPTION
コンテンツ管理一覧画面にアクセスした際にカレントサイトのコンテンツが初期表示されるように変更いたしました。
ご確認よろしくお願いいたします！