### PR TITLE
アクセス権限がないページにアクセスするとリダイレクトループになる

### DIFF
--- a/plugins/baser-core/src/Controller/Admin/BcAdminAppController.php
+++ b/plugins/baser-core/src/Controller/Admin/BcAdminAppController.php
@@ -90,7 +90,7 @@ class BcAdminAppController extends BcAppController
         $permission = $this->getService(PermissionsServiceInterface::class);
         if ($user && !$permission->check($this->getRequest()->getPath(), Hash::extract($user->toArray()['user_groups'], '{n}.id'))) {
             $this->BcMessage->setError(__d('baser', '指定されたページへのアクセスは許可されていません。'));
-            $this->redirect($this->Authentication->getLoginRedirect());
+            $this->redirect(Router::url(Configure::read('BcPrefixAuth.Admin.loginRedirect')));
         }
     }
 


### PR DESCRIPTION
アクセス権限がないページにアクセスするとリダイレクトループになる問題を修正しました。

ご確認お願いします。