### PR TITLE
fix #1268 ContentsAdminService::getViewVarsForTrashIndex() のユニットテスト実装…

### DIFF
--- a/plugins/baser-core/src/Service/Admin/ContentsAdminService.php
+++ b/plugins/baser-core/src/Service/Admin/ContentsAdminService.php
@@ -149,6 +149,7 @@ class ContentsAdminService extends ContentsService implements ContentsAdminServi
      * @return array
      * @noTodo
      * @checked
+     * @unitTest
      */
     public function getViewVarsForTrashIndex($contents)
     {

--- a/plugins/baser-core/tests/TestCase/Service/Admin/ContentsAdminServiceTest.php
+++ b/plugins/baser-core/tests/TestCase/Service/Admin/ContentsAdminServiceTest.php
@@ -161,6 +161,10 @@ class ContentsAdminServiceTest extends \BaserCore\TestSuite\BcTestCase
      */
     public function test_getViewVarsForTrashIndex()
     {
-        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+        $result = $this->ContentsAdmin->getViewVarsForTrashIndex($this->ContentsAdmin->get(5));
+        $this->assertArrayHasKey('contents', $result);
+        $this->assertArrayHasKey('isContentDeletable', $result);
+        $this->assertArrayHasKey('isUseMoveContents', $result);
+        $this->assertArrayHasKey('editInIndexDisabled', $result);
     }
 }


### PR DESCRIPTION
… #1268

