### PR TITLE
fix #1267 ContentsAdminService::getViewVarsForIndex() のユニットテスト見直し

### DIFF
--- a/plugins/baser-core/tests/TestCase/Service/Admin/ContentsAdminServiceTest.php
+++ b/plugins/baser-core/tests/TestCase/Service/Admin/ContentsAdminServiceTest.php
@@ -131,6 +131,12 @@ class ContentsAdminServiceTest extends \BaserCore\TestSuite\BcTestCase
         $this->assertTrue(isset($vars['typeList']));
         $this->assertTrue(isset($vars['authorList']));
         $this->assertTrue(isset($vars['isContentDeletable']));
+        $this->assertTrue(isset($vars['folders']));
+        $this->assertTrue(isset($vars['template']));
+        $this->assertTrue(isset($vars['editInIndexDisabled']));
+        $this->assertTrue(isset($vars['isUseMoveContents']));
+        $this->assertTrue(isset($vars['contents']));
+        $this->assertTrue(isset($vars['contentsSearch']));
     }
 
     /**

--- a/plugins/baser-core/tests/TestCase/Utility/BcUtilTest.php
+++ b/plugins/baser-core/tests/TestCase/Utility/BcUtilTest.php
@@ -571,14 +571,14 @@ class BcUtilTest extends BcTestCase
      *
      * @param $input
      * @param $expected
-     * @dataProvider urlencodeProvider
+     * @dataProvider urlencodeDataProvider
      */
     public function testUrlencode($input, $expected)
     {
         $this->assertEquals($expected, BcUtil::urlencode($input));
     }
 
-    public function urlencodeProvider(): array
+    public function urlencodeDataProvider(): array
     {
         return [
             ['a=b+c', 'a_b_c'],

--- a/plugins/baser-core/tests/TestCase/Utility/BcUtilTest.php
+++ b/plugins/baser-core/tests/TestCase/Utility/BcUtilTest.php
@@ -571,14 +571,14 @@ class BcUtilTest extends BcTestCase
      *
      * @param $input
      * @param $expected
-     * @dataProvider testUrlencodeDataProvider
+     * @dataProvider urlencodeDataProvider
      */
     public function testUrlencode($input, $expected)
     {
         $this->assertEquals($expected, BcUtil::urlencode($input));
     }
 
-    public function testUrlencodeDataProvider(): array
+    public function urlencodeDataProvider(): array
     {
         return [
             ['a=b+c', 'a_b_c'],

--- a/plugins/baser-core/tests/TestCase/Utility/BcUtilTest.php
+++ b/plugins/baser-core/tests/TestCase/Utility/BcUtilTest.php
@@ -571,14 +571,14 @@ class BcUtilTest extends BcTestCase
      *
      * @param $input
      * @param $expected
-     * @dataProvider urlencodeDataProvider
+     * @dataProvider testUrlencodeDataProvider
      */
     public function testUrlencode($input, $expected)
     {
         $this->assertEquals($expected, BcUtil::urlencode($input));
     }
 
-    public function urlencodeDataProvider(): array
+    public function testUrlencodeDataProvider(): array
     {
         return [
             ['a=b+c', 'a_b_c'],


### PR DESCRIPTION
#1267 を対応する
testUrlencodeのデータプロバイダのメソード名を修正する