### PR TITLE
fix BcDatabaseService::getDataSource のユニットテスト実装 #1689

### DIFF
--- a/plugins/baser-core/src/Service/BcDatabaseService.php
+++ b/plugins/baser-core/src/Service/BcDatabaseService.php
@@ -1120,6 +1120,9 @@ class BcDatabaseService implements BcDatabaseServiceInterface
      * @param string $configKeyName
      * @param array $dbConfig
      * @return Connection
+     * @checked
+     * @noTodo
+     * @unitTest
      */
     public function getDataSource($dbConfigKeyName = 'default', $dbConfig = null)
     {

--- a/plugins/baser-core/tests/TestCase/Service/BcDatabaseServiceTest.php
+++ b/plugins/baser-core/tests/TestCase/Service/BcDatabaseServiceTest.php
@@ -561,7 +561,23 @@ class UserActionsSchema extends BcSchema
      */
     public function test_getDataSource()
     {
-        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+        $conn = $this->BcDatabaseService->getDataSource();
+        $config = $this->getPrivateProperty($conn, "_config");
+        $this->assertEquals('test_basercms', $config['database'], 'データソースが取得できること');
+
+        // 指定されたデータソースが存在しない場合はエラー
+        $this->expectException('\Cake\Datasource\Exception\MissingDatasourceConfigException');
+        $conn = $this->BcDatabaseService->getDataSource('test_config');
+    }
+
+    /**
+     * Test getDataSource (MissingDatasourceExceptionの場合)
+     */
+    public function test_getDataSourceMissingDatasourceException()
+    {
+        // 指定されたデータソースが存在しない場合はエラー
+        $this->expectException('\Cake\Datasource\Exception\MissingDatasourceException');
+        $conn = $this->BcDatabaseService->getDataSource('test_config', ['datasource' => 'mysql']);
     }
 
     /**

--- a/plugins/baser-core/tests/TestCase/Service/BcDatabaseServiceTest.php
+++ b/plugins/baser-core/tests/TestCase/Service/BcDatabaseServiceTest.php
@@ -565,6 +565,14 @@ class UserActionsSchema extends BcSchema
         $config = $this->getPrivateProperty($conn, "_config");
         $this->assertEquals('test_basercms', $config['database'], 'データソースが取得できること');
 
+        $conn = $this->BcDatabaseService->getDataSource('test');
+        $config = $this->getPrivateProperty($conn, "_config");
+        $this->assertEquals('test_basercms', $config['database'], 'データソースが取得できること');
+
+        $conn = $this->BcDatabaseService->getDataSource('test_debug_kit');
+        $config = $this->getPrivateProperty($conn, "_config");
+        $this->assertEquals('/var/www/html/tmp/debug_kit.sqlite', $config['database'], 'データソースが取得できること');
+
         // 指定されたデータソースが存在しない場合はエラー
         $this->expectException('\Cake\Datasource\Exception\MissingDatasourceConfigException');
         $conn = $this->BcDatabaseService->getDataSource('test_config');


### PR DESCRIPTION
データソースを取得できることを確認しています。
指定したデータソースが存在しない場合は例外となることを確認しています。