### PR TITLE
fix BcDatabaseService::deleteTables のユニットテスト実装 #1690

### DIFF
--- a/plugins/baser-core/src/Service/BcDatabaseService.php
+++ b/plugins/baser-core/src/Service/BcDatabaseService.php
@@ -1145,6 +1145,9 @@ class BcDatabaseService implements BcDatabaseServiceInterface
      * @param string $dbConfigKeyName
      * @param array $dbConfig
      * @return boolean
+     * @checked
+     * @noTodo
+     * @unitTest
      */
     public function deleteTables($dbConfigKeyName = 'default', $dbConfig = null)
     {

--- a/plugins/baser-core/tests/TestCase/Service/BcDatabaseServiceTest.php
+++ b/plugins/baser-core/tests/TestCase/Service/BcDatabaseServiceTest.php
@@ -578,8 +578,34 @@ class UserActionsSchema extends BcSchema
         $tables = $db->getSchemaCollection()->listTables();
         $this->assertCount(0, $tables, '全てのテーブルが削除されていること');
 
-        // tearDown でテーブルを truncate しており、テーブルが存在しないというエラーが出てしまうので、
-        // テーブルを再作成しておく
+        // 後処理
+        $this->test_deleteTablesForMigrations();
+    }
+
+    /**
+     * Test deleteTables 引数ありの場合
+     */
+    public function test_deleteTablesArgs()
+    {
+        // 対象メソッドを呼ぶ
+        $result = $this->BcDatabaseService->deleteTables('test', ['driver' => 'mysql']);
+        $this->assertTrue($result, 'テーブル削除が成功していること');
+
+        $db = $this->BcDatabaseService->getDataSource();
+        $tables = $db->getSchemaCollection()->listTables();
+        $this->assertCount(0, $tables, '全てのテーブルが削除されていること');
+
+        // 後処理
+        $this->test_deleteTablesForMigrations();
+    }
+
+    /**
+     * Test deleteTables
+     * tearDown でテーブルを truncate しており、テーブルが存在しないというエラーが出てしまうので、
+     * テーブルを再作成しておく
+     */
+    private function test_deleteTablesForMigrations()
+    {
         $migrations = new Migrations();
         $plugins = [
             'BaserCore',

--- a/plugins/baser-core/tests/TestCase/Service/BcDatabaseServiceTest.php
+++ b/plugins/baser-core/tests/TestCase/Service/BcDatabaseServiceTest.php
@@ -569,7 +569,17 @@ class UserActionsSchema extends BcSchema
      */
     public function test_deleteTables()
     {
-        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+        // 対象メソッドを呼ぶ
+        $result = $this->BcDatabaseService->deleteTables();
+        $this->assertTrue($result, 'テーブル削除が成功していること');
+
+        $db = $this->BcDatabaseService->getDataSource();
+        $tables = $db->getSchemaCollection()->listTables();
+        $this->assertCount(0, $tables, '全てのテーブルが削除されていること');
+
+        // tearDown でテーブルを truncate しており、テーブルが存在しないというエラーが出てしまうので、
+        // ここでは fixtureStrategy を使わない設定にしておく
+        $this->fixtureStrategy = null;
     }
 
     /**

--- a/plugins/baser-core/tests/TestCase/Service/BcDatabaseServiceTest.php
+++ b/plugins/baser-core/tests/TestCase/Service/BcDatabaseServiceTest.php
@@ -35,6 +35,7 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\Filesystem\File;
 use Cake\Utility\Inflector;
+use Migrations\Migrations;
 
 /**
  * BcDatabaseServiceTest
@@ -578,8 +579,25 @@ class UserActionsSchema extends BcSchema
         $this->assertCount(0, $tables, '全てのテーブルが削除されていること');
 
         // tearDown でテーブルを truncate しており、テーブルが存在しないというエラーが出てしまうので、
-        // ここでは fixtureStrategy を使わない設定にしておく
-        $this->fixtureStrategy = null;
+        // テーブルを再作成しておく
+        $migrations = new Migrations();
+        $plugins = [
+            'BaserCore',
+            'BcBlog',
+            'BcSearchIndex',
+            'BcContentLink',
+            'BcMail',
+            'BcWidgetArea',
+            'BcThemeConfig',
+            'BcThemeFile',
+        ];
+        foreach ($plugins as $plugin) {
+            $migrate = $migrations->migrate([
+                'connection' => 'test',
+                'plugin' => $plugin,
+            ]);
+            $this->assertTrue($migrate);
+        }
     }
 
     /**


### PR DESCRIPTION
テーブルが削除されていることを確認しています。
tearDown でテーブルを truncate しており、テーブルが存在しないというエラーが出てしまうので、
対象メソッド実行後、fixtureStrategy を使わない設定にしています。