### PR TITLE
fix #1688 BcDatabaseService::connectDb のユニットテスト実装

### DIFF
--- a/plugins/baser-core/src/Service/BcDatabaseService.php
+++ b/plugins/baser-core/src/Service/BcDatabaseService.php
@@ -1089,6 +1089,8 @@ class BcDatabaseService implements BcDatabaseServiceInterface
      * データベースに接続する
      *
      * @param array $config
+     * @return Connection
+     * @unitTest
      */
     public function connectDb(array $config, $name = 'default')
     {
@@ -1096,6 +1098,8 @@ class BcDatabaseService implements BcDatabaseServiceInterface
             $config['driver'] = $this->getDatasourceName($config['datasource']);
         }
         if (empty($config['driver'])) return ConnectionManager::get($name);
+        // 接続情報を再構成する場合は、情報を削除してから設定する
+        ConnectionManager::drop($name);
         ConnectionManager::setConfig($name, [
             'className' => Connection::class,
             'driver' => $config['driver'],

--- a/plugins/baser-core/src/Service/BcDatabaseService.php
+++ b/plugins/baser-core/src/Service/BcDatabaseService.php
@@ -1090,6 +1090,8 @@ class BcDatabaseService implements BcDatabaseServiceInterface
      *
      * @param array $config
      * @return Connection
+     * @checked
+     * @noTodo
      * @unitTest
      */
     public function connectDb(array $config, $name = 'default')

--- a/plugins/baser-core/tests/TestCase/Service/BcDatabaseServiceTest.php
+++ b/plugins/baser-core/tests/TestCase/Service/BcDatabaseServiceTest.php
@@ -553,7 +553,25 @@ class UserActionsSchema extends BcSchema
      */
     public function test_connectDb()
     {
-        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+        // 接続情報を設定
+        $config = [
+            "datasource" => "MySQL",
+            "database" => "test_basercms",
+            "host" => "bc5-db",
+            "port" => "3306",
+            "username" => "root",
+            "password" => "root",
+            "schema" => "",
+            "prefix" => "mysite_",
+            "encoding" => "utf8"
+        ];
+
+        // テスト対象メソッドを呼ぶ
+        $db = $this->BcDatabaseService->connectDb($config);
+
+        // 接続できていること
+        $this->assertNotEmpty($db);
+        $this->assertTrue($db->isConnected());
     }
 
     /**


### PR DESCRIPTION
接続できることを確認しています。
接続情報を再構成する場合は、情報を削除してから設定する必要があるため、dropしてからsetConfigするように修正しています。