### PR TITLE
ログイン処理の前後にイベントを追加

### DIFF
--- a/plugins/baser-core/src/Controller/Admin/UsersController.php
+++ b/plugins/baser-core/src/Controller/Admin/UsersController.php
@@ -63,10 +63,24 @@ class UsersController extends BcAdminAppController
     {
         $this->set($service->getViewVarsForLogin($this->getRequest()));
         $target = $this->Authentication->getLoginRedirect() ?? Router::url(Configure::read('BcPrefixAuth.Admin.loginRedirect'));
+
+        // EVENT Users.beforeLogin
+        $event = $this->dispatchLayerEvent('beforeLogin', [
+            'user' => $this->request
+        ]);
+        if ($event !== false) {
+            $this->request = ($event->getResult() === null || $event->getResult() === true)? $event->getData('user') : $event->getResult();
+        }
+
         if ($this->request->is('post')) {
             $result = $this->Authentication->getResult();
             if ($result->isValid()) {
                 $user = $result->getData();
+                // EVENT Users.afterLogin
+                $this->dispatchLayerEvent('afterLogin', [
+                    'user' => $user,
+                    'loginRedirect' => $target
+                ]);
                 $service->removeLoginKey($user->id);
                 if ($this->request->is('ssl') && $this->request->getData('saved')) {
                     // 自動ログイン保存


### PR DESCRIPTION
4系に存在していたbeforeLoginイベント、afterLoginイベントを追加しました。
意図的に移植していないものでしたらすみません。