### PR TITLE
fix #2064 ライブラリインストール失敗時のメッセージを調整

### DIFF
--- a/plugins/bc-installer/composer_installer.php
+++ b/plugins/bc-installer/composer_installer.php
@@ -78,7 +78,7 @@ function command($phpPath)
     if ($code !== 0) throw new Exception('composer のアップデートに失敗しました。');
     $command = "cd " . ROOT_DIR . "; export HOME={$composerDir} ; {$phpPath} {$composerDir}composer.phar install";
     exec($command, $out, $code);
-    if ($code !== 0) throw new Exception('ライブラリのインストールに失敗しました。');
+    if ($code !== 0) throw new Exception('ライブラリのインストールに失敗しました。<br>コマンド実行をお試しください<br>' . $command);
     copy(ROOT_DIR . 'config' . DS . '.env.example', ROOT_DIR . 'config' . DS . '.env');
 }
 


### PR DESCRIPTION
issue: https://github.com/baserproject/ucmitz/issues/2064

baserインストール時、ライブラリのインストールに失敗した際のメッセージを調整しています。

ご確認お願いします。