### PR TITLE
fix #2117 test修正追加

### DIFF
--- a/plugins/bc-mail/tests/TestCase/View/Helper/MailHelperTest.php
+++ b/plugins/bc-mail/tests/TestCase/View/Helper/MailHelperTest.php
@@ -131,7 +131,9 @@ class MailHelperTest extends BaserTestCase
         $expected = [
             'mail_default' => 'mail_default',
             'default' => 'default',
-            'reset_password' => 'reset_password'
+            'reset_password' => 'reset_password',
+            'send_activate_url' => 'send_activate_url',
+            'send_activate_urls' => 'send_activate_urls',
         ];
         $this->assertEquals($result, $expected, 'メールテンプレートの取得結果が違います。');
     }


### PR DESCRIPTION
- baserCMSバージョン4.4.7以降に作成されたコミットを baserCMS５に移行

