### PR TITLE
fix #2121 メールフィールドのinput type をemailに変更したことによるテーマの見た目の崩れが発生している件を修正

### DIFF
--- a/__assets/plugins/baser-core/config/theme/bccolumn/css/common.css
+++ b/__assets/plugins/baser-core/config/theme/bccolumn/css/common.css
@@ -42,7 +42,7 @@ q:before, q:after {
   /*padding: 0;*/
 /*}*/
 
-input[type=text], textarea, select, input[type=password] {
+input[type=text], input[type=email], textarea, select, input[type=password] {
 	margin:3px 2px;
 	padding: 3px 1px;
 	border:1px solid #ccc;
@@ -59,14 +59,14 @@ input[type=checkbox] {
 	margin-left:5px;
 	margin-right:5px;
 }
-input[type=text], textarea, input[type=password] {
+input[type=text], input[type=email], textarea, input[type=password] {
 	font-size: 1.3em;
 	padding: 3px 3px;
 }
 textarea {
 	width:95%;
 }
-input[type=text], input[type=password] {
+input[type=text], input[type=email], input[type=password] {
 	line-height: 1.3em;
 }
 select {
@@ -211,12 +211,12 @@ img {
   opacity: 0.7;
 }
 @media screen and (max-width: 640px){
-    
+
     #Contents a:hover img:not([class="Over"]) {
       filter: alpha(opacity=100);
       opacity: 1;
     }
-    
+
 }
 
 /* layout
@@ -234,9 +234,9 @@ img {
 	.forPC {
 	  display: none;
 	}
-	
+
 	.forSP {
 	  display: block;
 	}
-	
+
 }


### PR DESCRIPTION
- baserCMSバージョン4.4.7以降に作成されたコミットを baserCMS５に移行

