### PR TITLE
fix #2124 【フォーム】フィールド設定にて、「表示サイズ」に数値以外を入力するとシステムエラーになる件の修正

### DIFF
--- a/plugins/bc-mail/src/Model/Table/MailFieldsTable.php
+++ b/plugins/bc-mail/src/Model/Table/MailFieldsTable.php
@@ -128,6 +128,18 @@ class MailFieldsTable extends MailAppTable
         $validator
             ->scalar('group_valid')
             ->maxLength('group_valid', 255, __d('baser_core', 'グループ入力チェックは255文字以内で入力してください。'));
+        $validator
+            ->scalar('size')
+            ->naturalNumber('size', __d('baser_core', '表示サイズは半角数字のみで入力してください。'))
+            ->maxLength('size', 9, __d('baser_core', '表示サイズは9文字以内で入力してください。'));
+        $validator
+            ->scalar('rows')
+            ->naturalNumber('rows', __d('baser_core', '行数は半角数字のみで入力してください。'))
+            ->maxLength('rows', 9, __d('baser_core', '行数は9文字以内で入力してください。'));
+        $validator
+            ->scalar('maxlength')
+            ->naturalNumber('maxlength', __d('baser_core', '最大値は半角数字のみで入力してください。'))
+            ->maxLength('maxlength', 9, __d('baser_core', '最大値は9文字以内で入力してください。'));
         return $validator;
     }
 


### PR DESCRIPTION
- baserCMSバージョン4.4.7以降に作成されたコミットを baserCMS５に移行

