### PR TITLE
fix #2130 ヘルプのバルーンチップをサイドバーより前面に表示

### DIFF
--- a/plugins/bc-admin-third/src/css/components/_main.scss
+++ b/plugins/bc-admin-third/src/css/components/_main.scss
@@ -2,7 +2,6 @@
   font-size: $label_font_size_small;
   position: relative;
   flex-basis: 100%;
-  overflow: auto;
   background: $color_background_primary;
   line-height:1.4;
   // border-top: 1px solid #ccc;
@@ -10,6 +9,7 @@
   // ❗ .contents-body と同じ要素 ❗
   &__body {
     padding: 0;
+    overflow: auto;
     //a:link {
     //  color:$color_primary;
     //}

--- a/plugins/bc-admin-third/webroot/css/admin/style.css
+++ b/plugins/bc-admin-third/webroot/css/admin/style.css
@@ -5575,6 +5575,7 @@ body * {
 }
 .bca-main__body {
   padding: 0;
+  overflow: auto;
 }
 .bca-main__contents {
   padding: 20px;


### PR DESCRIPTION
- baserCMSバージョン4.4.7以降に作成されたコミットを baserCMS５に移行

