### PR TITLE
記事一覧の公開ボタンを修正

### DIFF
--- a/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogPosts/index_row.php
+++ b/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogPosts/index_row.php
@@ -109,8 +109,8 @@ use Cake\Utility\Hash;
       ['action' => 'publish', $post->blog_content->id, $post->id],
       [
         'title' => __d('baser_core', '公開'),
-        'class' => 'btn-unpublish bca-btn-icon',
-        'data-bca-btn-type' => 'unpublish',
+        'class' => 'btn-publish bca-btn-icon',
+        'data-bca-btn-type' => 'publish',
         'data-bca-btn-size' => 'lg']
     ) ?>
     <?php endif ?>


### PR DESCRIPTION
記事が非公開の場合に公開ボタンではなく非公開ボタンが表示されていたので調整しました。