### PR TITLE
BlogHelperのpostsメソッドで公開記事のみ取得ができない問題を修正

### DIFF
--- a/plugins/bc-blog/src/View/Helper/BlogHelper.php
+++ b/plugins/bc-blog/src/View/Helper/BlogHelper.php
@@ -1590,6 +1590,10 @@ class BlogHelper extends Helper
             'data' => [],
         ], $options);
 
+        if ($options['preview'] === false) {
+            $options['status'] = 'publish';
+        }
+
         if (!$contentsName && empty($options['contentsTemplate'])) {
             throw new BcException(__d('baser_core', '$contentsName を省略時は、contentsTemplate オプションで、コンテンツテンプレート名を指定してください。'));
         }


### PR DESCRIPTION
BlogPostsService::createIndexConditionsでは以下のコードのように`'status' => 'publish'` `'preview' => false` の場合に公開記事を取得するようでしたので調整しました。
```
       // ステータス
        if (($params['status'] === 'publish' || (string)$params['status'] === '1') && !$params['preview']) {
            $conditions = $this->BlogPosts->getConditionAllowPublish();
        } elseif ((string)$params['status'] === '0') {
            $conditions = ['BlogPosts.status' => false];
        } else {
            $conditions = [];
        }
```