### PR TITLE
BcUploadHelperのfileLinkメソッドを調整

### DIFF
--- a/plugins/baser-core/src/View/Helper/BcUploadHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcUploadHelper.php
@@ -144,6 +144,10 @@ class BcUploadHelper  extends Helper
 
         if (empty($options['value'])) {
             $value = Hash::get($entity, $fieldName);
+            if (!$value && strpos($fieldName, '.') !== false) {
+                [, $fieldName] = explode('.', $fieldName);
+                $value = Hash::get($entity, $fieldName);
+            }
         } else {
             $value = $options['value'];
         }


### PR DESCRIPTION
`$this->BcAdminForm->control('Model.field_name', ['type' => 'file"])`のように`モデル名.フィールド名`の形式の場合、画像が表示されない問題を修正しました。

ご確認お願いします。