### PR TITLE
BcFileUploaderのセットアップ処理を調整

### DIFF
--- a/plugins/baser-core/src/Utility/BcFileUploader.php
+++ b/plugins/baser-core/src/Utility/BcFileUploader.php
@@ -191,6 +191,7 @@ class BcFileUploader
         $files = [];
         foreach($this->settings['fields'] as $setting) {
             $name = $setting['name'];
+            $file = [];
             if (!empty($data[$name]) && is_array($data[$name])) {
                 $file = $data[$name];
                 $file['uploadable'] = $this->isUploadable($setting['type'], $file['type'], $file);


### PR DESCRIPTION
意図しないデータが格納される可能性があったため、for文の先頭に変数を初期化する処理を追加しました。