### PR TITLE
メールフィールド一覧取得APIを調整

### DIFF
--- a/plugins/bc-mail/src/Controller/Api/MailFieldsController.php
+++ b/plugins/bc-mail/src/Controller/Api/MailFieldsController.php
@@ -47,7 +47,7 @@ class MailFieldsController extends BcApiController
         $mailFields = $message = null;
         try {
             $queryParams = array_merge([
-                'contain' => null,
+                'contain' => ['MailContents' => ['Contents']],
                 'status' => 'publish'
             ], $queryParams);
             $mailFields = $this->paginate($service->getIndex($mailContentId, $queryParams));


### PR DESCRIPTION
`'status' => 'publish'`の場合は`Contents.status`を検索条件に利用するため調整しました。