### PR TITLE
fix #1880 メールフォームのマルチチェックボックスなどで（）などを使用すると、inputタグのidのみ（）が外れ、labelのチェ…

### DIFF
--- a/plugins/baser-core/src/View/Helper/BcFormHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcFormHelper.php
@@ -1184,7 +1184,7 @@ SCRIPT_END;
                     if ($attributes['style'] === 'checkbox') {
                         $htmlOptions['value'] = $name;
 
-                        $tagName = $attributes['id'] . $this->domIdSuffix($name);
+                        $tagName = $attributes['id'] . $this->domIdSuffix($name, 'html5');
                         $htmlOptions['id'] = $tagName;
                         $label = ['for' => $tagName];
 
@@ -1521,7 +1521,7 @@ SCRIPT_END;
             if ($disabled && (!is_array($disabled) || in_array((string)$optValue, $disabled, !$isNumeric))) {
                 $optionsHere['disabled'] = true;
             }
-            $tagName = $attributes['id'] . $this->domIdSuffix($optValue);
+            $tagName = $attributes['id'] . $this->domIdSuffix($optValue, 'html5');
 
             if ($label) {
                 $labelOpts = is_array($label)? $label : [];


### PR DESCRIPTION
…ックが効かなくなる問題を解決
@ryuring 
@gondoh 
@kaburk 

ご確認の上マージお願いします。
