### PR TITLE
fix #2220 （未ログイン時）管理画面にアクセスした際のエラーメッセージを表示しないように修正

### DIFF
--- a/plugins/baser-core/src/Controller/AppController.php
+++ b/plugins/baser-core/src/Controller/AppController.php
@@ -164,7 +164,9 @@ class AppController extends BaseController
             if ($prefix === 'Api/Admin') {
                 throw new ForbiddenException(__d('baser_core', '指定されたAPIエンドポイントへのアクセスは許可されていません。'));
             } else {
-                $this->BcMessage->setError(__d('baser_core', '指定されたページへのアクセスは許可されていません。'));
+                if (BcUtil::loginUser()) {
+                    $this->BcMessage->setError(__d('baser_core', '指定されたページへのアクセスは許可されていません。'));
+                }
                 return $this->redirect(Configure::read("BcPrefixAuth.{$prefix}.loginRedirect"));
             }
         }


### PR DESCRIPTION
ログイン周りが変わっていることもあり、ログイン中かどうか判定して未ログイン時はメッセージ非表示にしてみました。
よろしくおねがいします。

https://github.com/baserproject/basercms/commit/405ae1c5db1b0354153954c486e2c5b71e6ac273
