### PR TITLE
fix #2221【システム】BcAppController::setMessage()の使用箇所を修正

### DIFF
--- a/plugins/baser-core/src/Controller/BcAppController.php
+++ b/plugins/baser-core/src/Controller/BcAppController.php
@@ -435,7 +435,7 @@ class BcAppController extends AppController
         try {
             $cakeEmail->from($from, $fromName);
         } catch (Exception $e) {
-            $this->setMessage($e->getMessage() . ' ' . __d('baser_core', '送信元のメールアドレスが不正です。'), true, false, true);
+            $this->BcMessage->setError($e->getMessage() . ' ' . __d('baser', '送信元のメールアドレスが不正です。'));
             return false;
         }
 

--- a/plugins/baser-core/src/Controller/BcAppController.php
+++ b/plugins/baser-core/src/Controller/BcAppController.php
@@ -435,7 +435,7 @@ class BcAppController extends AppController
         try {
             $cakeEmail->from($from, $fromName);
         } catch (Exception $e) {
-            $this->BcMessage->setError($e->getMessage() . ' ' . __d('baser', '送信元のメールアドレスが不正です。'));
+            $this->BcMessage->setError($e->getMessage() . ' ' . __d('baser_core', '送信元のメールアドレスが不正です。'));
             return false;
         }
 


### PR DESCRIPTION
非推奨になった BcAppController::setMessage() を BcMessage->set に変更

https://github.com/baserproject/basercms/commit/4655705b509cf1b2def50b091570ede87de5ba74