### PR TITLE
メール送信時のオプションを調整

### DIFF
--- a/plugins/bc-mail/src/Mailer/MailMessageMailer.php
+++ b/plugins/bc-mail/src/Mailer/MailMessageMailer.php
@@ -72,7 +72,7 @@ class MailMessageMailer extends BcMailer
         if (empty($options['toAdmin'])) return;
         foreach($options['toAdmin'] as $key => $value) {
             $method = 'set' . Inflector::camelize($key);
-            if (method_exists($this, $method)) continue;
+            if (!method_exists($this, $method) && !method_exists($this->message, $method)) continue;
             $this->{$method}($value);
         }
     }
@@ -116,7 +116,7 @@ class MailMessageMailer extends BcMailer
         if (empty($options['toUser'])) return;
         foreach($options['toUser'] as $key => $value) {
             $method = 'set' . Inflector::camelize($key);
-            if (!method_exists($this, $method)) continue;
+            if (!method_exists($this, $method) && !method_exists($this->message, $method)) continue;
             $this->{$method}($value);
         }
     }


### PR DESCRIPTION
メール送信前に、イベントで設定したオプションが適用されていないようなので調整を行いました。

以下のようなイベントを作成して動作を確認しています。

```
public function bcMailMailBeforeSendEmail(EventInterface $event)
{
    $event->setData('sendEmailOptions', [
        'toAdmin' => [
            'from' => ['from-to-admin@example.com' => '管理者宛from'],
        ],
        'toUser' => [
            'from' => ['from-to-user@example.com' => 'ユーザー宛from'],
        ],
    ]);
}
```

setFromなどの関数はMailerクラス内に存在せず、以下のようにMessageクラスに存在するため関数の存在チェックの幅を広げています。

https://github.com/cakephp/cakephp/blob/4.x/src/Mailer/Mailer.php#L291
https://github.com/cakephp/cakephp/blob/4.x/src/Mailer/Message.php#L334

ご確認お願いします。
