### PR TITLE
smtpの場合のEmailのトランスポート設定を調整

### DIFF
--- a/plugins/baser-core/src/Mailer/BcMailer.php
+++ b/plugins/baser-core/src/Mailer/BcMailer.php
@@ -68,7 +68,9 @@ class BcMailer extends Mailer
             ];
             if ($siteConfig->smtp_port) $config['port'] = $siteConfig->smtp_port;
             if ($siteConfig->smtp_tls) $config['tls'] = $siteConfig->smtp_tls;
-            TransportFactory::setConfig($type, $config);
+            if (!TransportFactory::getConfig($type)) {
+                TransportFactory::setConfig($type, $config);
+            }
         } else {
             $type = 'default';
             if ($siteConfig->mail_additional_parameters) {


### PR DESCRIPTION
フォーム送信時のユーザー宛にメールが送信されるタイミングでエラーがでていたので修正しました。

管理者宛のメール送信の際にStaticConfigTrait::setConfigを呼び出し、ユーザー宛にメールが送信でも同じキーでsetConfigを呼び出すため、同じキーで再設定しようとしてエラーが出ていたようです。